### PR TITLE
Dev: Expanded Python cmp, Improvements

### DIFF
--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -52,7 +52,7 @@ void set_center(CtrT &lhs, const util::ProdCSparseVector<VT, IT> &rhs) {
 template<typename CtrT, typename VT, typename IT>
 void set_center(CtrT &lhs, const util::CSparseVector<VT, IT> &rhs) {
     lhs.reserve(rhs.nnz());
-    if(lhs.size() != rhs.dim_) lhs.resize(rhs.dim_);
+    if(lhs.size() != rhs.dim_) throw std::runtime_error("lhs size is not correct.");
     lhs.reset();
     for(const auto &pair: rhs) lhs[pair.index()] = pair.value();
 }

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -33,9 +33,7 @@ static constexpr const char *cp2str(CentroidPol pol) {
 
 template<typename CtrT, typename VT, bool TF>
 void set_center(CtrT &lhs, const blaze::Vector<VT, TF> &rhs) {
-    if(lhs.size() != (*rhs).size()) {
-        lhs.resize((*rhs).size());
-    }
+    if(lhs.size() != (*rhs).size()) throw std::runtime_error("lhs size is not correct.");
     if constexpr(blaze::IsSparseVector_v<CtrT>) {
         lhs.reserve((*rhs).size());
     }

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -611,7 +611,7 @@ void set_centroids_full_mean(const Mat &mat,
     auto assigned = std::make_unique<std::vector<size_t>[]>(k);
     OMP_ONLY(std::unique_ptr<std::mutex[]> locks(new std::mutex[k]);)
     for(size_t i = 0; i < np; ++i) {
-        OMP_ONLY(std::lock_guard<std::mutex> lock(locks(asn[i]));)
+        OMP_ONLY(std::lock_guard<std::mutex> lock(locks[asn[i]]);)
         assigned[asn[i]].push_back(i);
     }
     for(unsigned i = 0; i < k; ++i)

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -56,18 +56,20 @@ void set_center(CtrT &ctr, const util::CSparseMatrix<DataT, IndicesT, IndPtrT> &
     using VT = std::conditional_t<std::is_floating_point_v<DataT>, DataT, std::conditional_t<(sizeof(DataT) < 8), float, double>>;
     blz::DV<VT, blz::TransposeFlag_v<CtrT>> mv(mat.columns(), VT(0));
     double wsum = 0.;
-    OMP_PFOR_DYN
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(dynamic) reduction(+:wsum)
+#endif
     for(size_t i = 0; i < nasn; ++i) {
-        for(const auto &pair: row(mat, asn[i])) {
-            VT v = pair.value();
-            if(w) {
-                auto wv = (*w)[asn[i]];
+        const double itemw = w ? double(*w)[asn[i]]: 1.;
+        if(w) {
+            wsum += itemw;
+            for(const auto &pair: row(mat, asn[i])) {
                 OMP_ATOMIC
-                wsum += wv;
-                v *= wv;
+                mv[pair.index()] += pair.value() * itemw;
             }
+        } else for(const auto &pair: row(mat, asn[i])) {
             OMP_ATOMIC
-            mv[pair.index()] += v;
+            mv[pair.index()] += pair.value();
         }
     }
     if(!wsum) wsum = nasn;
@@ -604,19 +606,15 @@ void set_centroids_full_mean(const Mat &mat,
     //
 
     assert(asn.size() == costs.size() || !std::fprintf(stderr, "asn size %zu, cost size %zu\n", asn.size(), costs.size()));
-    //using asn_t = std::decay_t<decltype(asn[0])>;
     blaze::SmallArray<size_t, 16> sa;
     wy::WyRand<size_t, 4> rng(costs.size()); // Used for restarting orphaned centers
-    blz::DV<FT> pdf;
     const size_t np = costs.size(), k = ctrs.size();
     auto assigned = std::make_unique<std::vector<size_t>[]>(k);
-    //set_asn:
+    OMP_ONLY(std::unique_ptr<std::mutex[]> locks(k);)
     for(size_t i = 0; i < np; ++i) {
+        OMP_ONLY(std::lock_guard<std::mutex> lock(locks(asn[i]));)
         assigned[asn[i]].push_back(i);
     }
-#ifndef NDEBUG
-    for(unsigned i = 0; i < k; ++i) std::fprintf(stderr, "Center %u has %zu assigned points\n", i, assigned[i].size());
-#endif
     for(unsigned i = 0; i < k; ++i)
         if(assigned[i].empty())
             blz::push_back(sa, i);
@@ -692,18 +690,8 @@ void set_centroids_full_mean(const Mat &mat,
                 costs[pid] = 0.;
                 assigned[cid].push_back(pid);
             }
-#if 0
-            if(asn[rs[i]] != sa[i]) {
-                DBG_ONLY(std::fprintf(stderr, "Point %zd is not assigned to itself (%zd, empty #%zd). Cost: %g. Cost with itself: %g\n", rs[i], sa[i], i, costs[rs[i]], cmp::msr_with_prior(measure, ctrs[sa[i]], ctrs[sa[i]], prior, psum, ctrsums[sa[i]], ctrsums[sa[i]]));)
-                asn[rs[i]] = sa[i];
-            }
-#endif
         }
     }
-#if defined(_OPENMP) && !BLAZE_USE_SHARED_MEMORY_PARALLELIZATION
-    #pragma message("Parallelizing loop, may cause things to break")
-    #pragma omp parallel for
-#endif
     for(unsigned i = 0; i < k; ++i) {
         DBG_ONLY(std::fprintf(stderr, "Computing mean for centroid %u with %zu assigned points\n", i, assigned[i].size());)
         // Compute mean for centroid
@@ -743,13 +731,9 @@ double set_centroids_full_mean(const Mat &mat,
     WeightsT *weights, FT temp, SumT &ctrsums)
 {
     assert(ctrsums.size() == ctrs.size());
-    //std::fprintf(stderr, "Calling set_centroids_full_mean with weights = %p, temp = %g\n", (void *)weights, temp);
 
     const unsigned k = ctrs.size();
-    //blz::DV<FT, blz::rowVector> wsums(k, 0.), asn(k, 0.);
     asns = softmax<rowwise>(costs * -temp);
-    //std::cerr << softmaxcosts << '\n';
-    //std::fprintf(stderr, "costs are of dim %zu/%zu\n", softmaxcosts.rows(), softmaxcosts.columns());
     double ret = 0.;
     OMP_PRAGMA("omp parallel for reduction(+:ret)")
     for(size_t i = 0; i < asns.rows(); ++i) {

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -617,7 +617,7 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
 }
 
 template<typename FT=double, typename Mat, typename PriorT, typename AsnT, typename CostsT, typename CtrsT, typename WeightsT, typename IT=uint32_t, typename SumT>
-void set_centroids_full_mean(const Mat &mat,
+bool set_centroids_full_mean(const Mat &mat,
     const dist::DissimilarityMeasure measure,
     const PriorT &prior, AsnT &asn, CostsT &costs, CtrsT &ctrs,
     WeightsT *weights, SumT &ctrsums, const SumT &rowsums)
@@ -653,7 +653,9 @@ void set_centroids_full_mean(const Mat &mat,
     }
     assert(!nfails);
 #endif
+    bool restarted_any = false;
     if(const size_t ne = sa.size()) {
+        restarted_any = true;
         char buf[256];
         const auto pv = prior.size() ? FT(prior[0]): FT(0);
         std::sprintf(buf, "Restarting centers with no support for set_centroids_full_mean: %s as measure with prior of size %zu (%g)\n",
@@ -738,6 +740,7 @@ void set_centroids_full_mean(const Mat &mat,
             set_center(ctr, mat, asp, nasn, weights, isnorm ? static_cast<const SumT *>(nullptr): &rowsums);
         }
     }
+    return restarted_any;
 }
 
 template<typename Vector, typename AT, bool ATF>

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -141,14 +141,13 @@ using namespace ::minicore::distance;
 
 static constexpr INLINE CentroidPol msr2pol(distance::DissimilarityMeasure msr) {
     switch(msr) {
-        case EMD: case WEMD:
         case ORACLE_METRIC: case ORACLE_PSEUDOMETRIC:
         default:
             return NOT_APPLICABLE;
 
 
-        case UWLLR: case LLR: case MKL: case JSD: case SQRL2: case POISSON:
-        case REVERSE_POISSON: case REVERSE_MKL: case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
+        case UWLLR: case LLR: case MKL: case JSD: case SQRL2:
+        case REVERSE_MKL: case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
         case SYMMETRIC_ITAKURA_SAITO: case RSYMMETRIC_ITAKURA_SAITO:
 
         case SRULRT: case SRLRT: case JSM:
@@ -192,7 +191,7 @@ struct CentroidPolicy {
                 coresets::l1_median(cm, ret, wc->data());
             else
                 coresets::l1_median(cm, ret);
-        } else if(measure == dist::LLR || measure == dist::UWLLR || measure == dist::OLLR) {
+        } else if(measure == dist::LLR || measure == dist::UWLLR) {
             PRETTY_SAY << "LLR test\n";
             FT total_sum_inv;
             if(wc) {
@@ -289,7 +288,7 @@ struct CentroidPolicy {
                 }
             }
             double div;
-            if(measure == dist::LLR || measure == dist::OLLR || measure == dist::UWLLR) {
+            if(measure == dist::LLR || measure == dist::UWLLR) {
                 if(weight_cv)
                     div = sum(blz::elements(rs * **weight_cv, aip, ain));
                 else
@@ -382,7 +381,7 @@ struct CentroidPolicy {
                     }
                 }
             }
-            if(measure == dist::LLR || measure == dist::UWLLR || measure == dist::OLLR) {
+            if(measure == dist::LLR || measure == dist::UWLLR) {
                 OMP_PFOR
                 for(auto i = 0u; i < newcon.size(); ++i)
                     newcon[i] *= 1. / blz::dot(column(assignments, i), rs);

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -722,7 +722,7 @@ bool set_centroids_full_mean(const Mat &mat,
     }
     for(unsigned i = 0; i < k; ++i) shared::sort(assigned[i].begin(), assigned[i].end());
     for(unsigned i = 0; i < k; ++i) {
-        DBG_ONLY(std::fprintf(stderr, "Computing %smean for centroid %u with %zu assigned points\n", isnorm ? "normalized": "", i, assigned[i].size());)
+        //DBG_ONLY(std::fprintf(stderr, "Computing %smean for centroid %u with %zu assigned points\n", isnorm ? "normalized": "", i, assigned[i].size());)
         // Compute mean for centroid
         const auto nasn = assigned[i].size();
         const auto asp = assigned[i].data();

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -697,12 +697,11 @@ void set_centroids_full_mean(const Mat &mat,
         const auto nasn = assigned[i].size();
         const auto asp = assigned[i].data();
         auto &ctr = ctrs[i];
-        if(nasn == 1) {
+        if(nasn == 0) continue;
+        else if(nasn == 1) {
             auto mr = row(mat, *asp);
             assert(ctr.size() == mr.size());
             set_center(ctr, mr);
-        } else if(nasn == 0) {
-            // do nothing
         } else {
             set_center(ctr, mat, asp, nasn, weights);
         }

--- a/include/minicore/clustering/solve.h
+++ b/include/minicore/clustering/solve.h
@@ -587,8 +587,6 @@ auto hmb_coreset_clustering(const Matrix &mat,
         return ret;
     };
     const size_t np = costs.size(), k = centers.size();
-    auto perform_assign = [&]() {
-    };
     wy::WyRand<std::make_unsigned_t<IT>> rng(seed);
     schism::Schismatic<std::make_unsigned_t<IT>> div((mat).rows());
     blz::DV<IT> sampled_indices(mbsize);
@@ -692,9 +690,11 @@ auto hmb_coreset_clustering(const Matrix &mat,
             const size_t tnz = sum(blaze::generate(pts.size(), [&](auto x) {return nonZeros(row(mat, pts.indices_[x]));}));
             smat.reserve(tnz);
             OMP_PFOR
-            for(size_t i = 0; i < pts.indices_.size(); ++i)
-                row(smat, i) = row(mat, pts.indices_[i]);
-            using ResT = decltype(elements(*weights, pts.indices_.data(), pts.indices_.size()));
+            for(size_t i = 0; i < pts.indices_.size(); ++i) {
+                auto lh = row(smat, i);
+                set_center(lh, row(mat, pts.indices_[i]));
+            }
+                //row(smat, i) = row(mat, pts.indices_[i]);
             blz::DV<double> csw;
             if(weights) {
                 csw = elements(*weights, pts.indices_.data(), pts.indices_.size()) * pts.weights_;

--- a/include/minicore/clustering/solve.h
+++ b/include/minicore/clustering/solve.h
@@ -107,11 +107,6 @@ perform_hard_clustering(const MT &mat,
     const blz::DV<FT> rowsums = sum<blz::rowwise>(mat);
     blz::DV<FT> centersums = blaze::generate(centers.size(), [&](auto x){return sum(centers[x]);});
     assign_points_hard<FT>(mat, measure, prior, centers, asn, costs, weights, centersums, rowsums); // Assign points myself
-#ifndef NDEBUG
-    for(size_t i = 0; i < centers.size(); ++i) {
-        assert(std::abs(sum(centers[i]) - centersums[i]) < 1e-10 || !std::fprintf(stderr, "%g, %g, %i\n", sum(centers[i]),  centersums[i], int(i)));
-    }
-#endif
     const auto initcost = compute_cost();
     FT cost = initcost;
     std::fprintf(stderr, "[%s] initial cost: %0.12g\n", __PRETTY_FUNCTION__, cost);
@@ -133,7 +128,6 @@ perform_hard_clustering(const MT &mat,
             std::cerr << "Warning: New cost " << newcost << " > original cost " << cost << ". Using prior iteration.\n;";
             centersums = blaze::generate(centers.size(), [&](auto x) {return sum(centers[x]);});
             assign_points_hard<FT>(mat, measure, prior, centers, asn, costs, weights, centersums, rowsums);
-            //DBG_ONLY(std::abort();)
             break;
         }
         std::copy(centers_cpy.begin(), centers_cpy.begin(), centers.begin());
@@ -145,9 +139,7 @@ perform_hard_clustering(const MT &mat,
             break;
         }
         if(++iternum == maxiter) {
-#ifndef NDEBUG
             std::fprintf(stderr, "Maximum iterations [%zu] reached\n", iternum);
-#endif
             break;
         }
         cost = newcost;
@@ -548,7 +540,7 @@ auto perform_hard_minibatch_clustering(const Matrix &mat,
             } else {
                 clustering::set_center(centers[i], mat, asnptr, asnsz, weights);
             }
-            //std::cerr << trans(centers[i]) << '\n';
+            //std::cerr << "Center[" << i << "] " << trans(centers[i]) << '\n';
             VERBOSE_ONLY(std::cerr << "##center with sum " << sum(centers[i]) << " and index "  << i << ": " << centers[i] << '\n';)
             centersums[i] = sum(centers[i]);
             VERBOSE_ONLY(std::fprintf(stderr, "center sum: %g. csums: %g\n", centersums[i], sum(centers[i]));)

--- a/include/minicore/clustering/solve.h
+++ b/include/minicore/clustering/solve.h
@@ -696,17 +696,20 @@ auto hmb_coreset_clustering(const Matrix &mat,
             }
                 //row(smat, i) = row(mat, pts.indices_[i]);
             blz::DV<double> csw;
-            if(weights) {
+            if(weights)
                 csw = elements(*weights, pts.indices_.data(), pts.indices_.size()) * pts.weights_;
-            } else csw = pts.weights_;
+            else
+                csw = pts.weights_;
             blz::DV<double> cscosts(pts.size());
             blz::DV<uint32_t> csasn(pts.size());
+            OMP_PFOR
             for(size_t i = 0; i < pts.size(); ++i) {
                 auto rs = rowsums[pts.indices_[i]];
-                auto bestscore = cmp::msr_with_prior<FT>(measure, row(smat, i, unchecked), centers[0], prior, prior_sum, rs, centersums[0]);
+                auto sr = row(smat, i, unchecked);
+                auto bestscore = cmp::msr_with_prior<FT>(measure, sr, centers[0], prior, prior_sum, rs, centersums[0]);
                 auto bestid = 0u;
                 for(size_t j = 1; j < k; ++j) {
-                    auto nscore = cmp::msr_with_prior<FT>(measure, row(smat, i, unchecked), centers[j], prior, prior_sum, rs, centersums[j]);
+                    auto nscore = cmp::msr_with_prior<FT>(measure, sr, centers[j], prior, prior_sum, rs, centersums[j]);
                     if(nscore < bestscore) bestid = j, bestscore = nscore;
                 }
                 csasn[i] = bestid;

--- a/include/minicore/clustering/solve.h
+++ b/include/minicore/clustering/solve.h
@@ -86,7 +86,7 @@ template<typename MT, // MatrixType
          typename CostsT,
          typename PriorT=blz::DynamicVector<FT, rowVector>,
          typename AsnT=blz::DynamicVector<uint32_t>,
-         typename WeightT=CtrT, // Vector Type
+         typename WeightT=blz::DynamicVector<FT>, // Vector Type
          typename=std::enable_if_t<std::is_floating_point_v<FT>>
         >
 std::tuple<double, double, size_t>
@@ -156,7 +156,7 @@ perform_hard_clustering(const MT &mat,
  * set_centroids_hard assumes that costs of points have been assigned
  *
  */
-template<typename FT, typename Mat, typename PriorT, typename CtrT, typename CostsT, typename AsnT, typename WeightT=CtrT, typename SumT>
+template<typename FT, typename Mat, typename PriorT, typename CtrT, typename CostsT, typename AsnT, typename WeightT=blz::DV<FT>, typename SumT>
 void set_centroids_hard(const Mat &mat,
                         const dist::DissimilarityMeasure measure,
                         const PriorT &prior,
@@ -175,7 +175,7 @@ void set_centroids_hard(const Mat &mat,
     const bool isnorm = msr_is_normalized(measure);
     switch(pol) {
         case JSM_MEDIAN:
-        case FULL_WEIGHTED_MEAN: set_centroids_full_mean<FT>(mat, measure, prior, asn, costs, centers, weights, ctrsums, rowsums);
+        case FULL_WEIGHTED_MEAN: set_centroids_full_mean<FT>(mat, measure, prior, asn, costs, centers, weights, ctrsums, rowsums, isnorm);
             break;
         case L1_MEDIAN:
             set_centroids_l1<FT>(mat, asn, costs, centers, weights);

--- a/include/minicore/clustering/solve.h
+++ b/include/minicore/clustering/solve.h
@@ -172,6 +172,7 @@ void set_centroids_hard(const Mat &mat,
     if(dist::is_bregman(measure)) {
         assert(FULL_WEIGHTED_MEAN == pol || JSM_MEDIAN == pol);
     }
+    const bool isnorm = msr_is_normalized(measure);
     switch(pol) {
         case JSM_MEDIAN:
         case FULL_WEIGHTED_MEAN: set_centroids_full_mean<FT>(mat, measure, prior, asn, costs, centers, weights, ctrsums, rowsums);

--- a/include/minicore/clustering/solve.h
+++ b/include/minicore/clustering/solve.h
@@ -510,7 +510,6 @@ auto perform_hard_minibatch_clustering(const Matrix &mat,
             shared::sort(assigned[i].begin(), assigned[i].end());
         }
         // 3. Calculate new center
-        const bool isnorm = msr_is_normalized(measure);
         OMP_PFOR
         for(size_t i = 0; i < centers.size(); ++i) {
             //const FT eta = center_wsums[i];

--- a/include/minicore/coreset/coreset.h
+++ b/include/minicore/coreset/coreset.h
@@ -152,8 +152,9 @@ struct IndexCoreset {
         }
         indices_.resize(newsz);
         weights_.resize(newsz);
-        DBG_ONLY(std::fprintf(stderr, "Shrinking to fit\n");)
+        DBG_ONLY(std::fprintf(stderr, "Shrinking to fit: start at %zu\n", size());)
         if(shrink_to_fit) indices_.shrinkToFit(), weights_.shrinkToFit();
+        DBG_ONLY(std::fprintf(stderr, "after shrinking: %zu\n", size());)
         return *this;
     }
     std::vector<std::pair<IT, FT>> to_pairs() const {

--- a/include/minicore/coreset/coreset.h
+++ b/include/minicore/coreset/coreset.h
@@ -343,7 +343,6 @@ struct CoresetSampler {
         // From Training Gaussian Mixture Models at Scale via Coresets
         // http://www.jmlr.org/papers/volume18/15-506/15-506.pdf
         // Note: this can be expanded to general probability measures.
-        throw std::runtime_error("I'm not certain this is correct. Do not use this until I am.");
         std::vector<FT> weight_sums(ncenters), weighted_cost_sums(ncenters);
         std::vector<FT> sqcosts(ncenters);
         std::vector<IT> center_counts(ncenters);

--- a/include/minicore/dist/applicator.h
+++ b/include/minicore/dist/applicator.h
@@ -25,16 +25,13 @@ using namespace minicore::distance;
             MACRO(SYMMETRIC_ITAKURA_SAITO) MACRO(RSYMMETRIC_ITAKURA_SAITO)\
             MACRO(COSINE_DISTANCE) MACRO(COSINE_SIMILARITY)\
             MACRO(PROBABILITY_COSINE_DISTANCE) MACRO(PROBABILITY_COSINE_SIMILARITY)\
-            MACRO(LLR) MACRO(OLLR) MACRO(UWLLR)\
+            MACRO(LLR) MACRO(UWLLR)\
             MACRO(BHATTACHARYYA_METRIC) MACRO(BHATTACHARYYA_DISTANCE)\
             MACRO(HELLINGER)\
-            MACRO(POISSON)\
-            MACRO(REVERSE_POISSON)\
             MACRO(JSD)\
             MACRO(JSM) MACRO(MKL) MACRO(REVERSE_MKL)\
-            MACRO(EMD) MACRO(WEMD)\
             MACRO(ITAKURA_SAITO) MACRO(REVERSE_ITAKURA_SAITO)\
-            MACRO(PL2) MACRO(PSL2) MACRO(L1) MACRO(L2) MACRO(SQRL2)\
+            MACRO(L1) MACRO(L2) MACRO(SQRL2)\
             MACRO(TOTAL_VARIATION_DISTANCE)
 
 template<typename MatrixType, typename ElementType=blaze::ElementType_t<MatrixType>>
@@ -311,10 +308,6 @@ public:
             ret = l2Norm(weighted_row(i) - o);
         } else if constexpr(constexpr_measure == SQRL2) {
             ret = blaze::sqrNorm(weighted_row(i) - o);
-        } else if constexpr(constexpr_measure == PSL2) {
-            ret = blaze::sqrNorm(i - o);
-        } else if constexpr(constexpr_measure == PL2) {
-            ret = p_l2norm(i, o);
         } else if constexpr(constexpr_measure == JSD) {
             if(cp) {
                 ret = jsd(i, o, *cp);
@@ -327,16 +320,6 @@ public:
             ret = cp ? mkl(i, o, *cp): mkl(i, o);
         } else if constexpr(constexpr_measure == MKL) {
             ret = cp ? mkl(o, i, *cp): mkl(o, i);
-        } else if constexpr(constexpr_measure == EMD) {
-            throw NotImplementedError("Removed: currently, p_wasserstein functions are not permitted");
-            ret = p_wasserstein(row(i), o);
-        } else if constexpr(constexpr_measure == WEMD) {
-            throw NotImplementedError("Removed: currently, p_wasserstein functions are not permitted");
-            ret = p_wasserstein(weighted_row(i), o);
-        } else if constexpr(constexpr_measure == REVERSE_POISSON) {
-            ret = cp ? pkl(i, o, *cp): pkl(i, o);
-        } else if constexpr(constexpr_measure == POISSON) {
-            ret = cp ? pkl(o, i, *cp): pkl(o, i);
         } else if constexpr(constexpr_measure == HELLINGER) {
             ret = cp ? blaze::sqrNorm(sqrtrow(i) - *cp)
                      : blaze::sqrNorm(sqrtrow(i) - blaze::sqrt(o));
@@ -348,8 +331,6 @@ public:
             ret = cp ? llr(i, o, *cp): llr(i, o);
         } else if constexpr(constexpr_measure == UWLLR) {
             ret = cp ? uwllr(i, o, *cp): uwllr(i, o);
-        } else if constexpr(constexpr_measure == OLLR) {
-            throw 1; // Not implemented
         } else if constexpr(constexpr_measure == ITAKURA_SAITO) {
             ret = itakura_saito(o, i);
         } else if constexpr(constexpr_measure == REVERSE_ITAKURA_SAITO) {
@@ -382,13 +363,9 @@ public:
             ret = l1Norm(weighted_row(i) - o);
         } else if constexpr(constexpr_measure == L2) {
             ret = l2Norm(weighted_row(i) - o);
-        } else if constexpr(constexpr_measure == PL2) {
-            ret = p_l2norm(i, o);
         } else if constexpr(constexpr_measure == SQRL2) {
             ret = blaze::sqrNorm(weighted_row(i) - o);
             //std::fprintf(stderr, "SQRL2 between row %zu and row starting at %p is %g\n", i, (void *)&*o.begin(), ret);
-        } else if constexpr(constexpr_measure == PSL2) {
-            ret = blaze::sqrNorm(i - o);
         } else if constexpr(constexpr_measure == JSD) {
             if(cp) {
                 ret = jsd(i, o, *cp);
@@ -405,16 +382,6 @@ public:
             if(cp) {
                 ret = mkl(i, o, *cp);
             } else ret = mkl(i, o);
-        } else if constexpr(constexpr_measure == EMD) {
-            throw NotImplementedError("Removed: currently, p_wasserstein functions are not permitted");
-            ret = p_wasserstein(row(i), o);
-        } else if constexpr(constexpr_measure == WEMD) {
-            throw NotImplementedError("Removed: currently, p_wasserstein functions are not permitted");
-            ret = p_wasserstein(weighted_row(i), o);
-        } else if constexpr(constexpr_measure == REVERSE_POISSON) {
-            ret = cp ? pkl(o, i, *cp): pkl(o, i);
-        } else if constexpr(constexpr_measure == POISSON) {
-            ret = cp ? pkl(i, o, *cp): pkl(i, o);
         } else if constexpr(constexpr_measure == HELLINGER) {
             if(cp) {
                 ret = blaze::sqrNorm(sqrtrow(i) - *cp);
@@ -431,9 +398,6 @@ public:
             ret = cp ? llr(i, o, *cp): llr(i, o);
         } else if constexpr(constexpr_measure == UWLLR) {
             ret = cp ? uwllr(i, o, *cp): uwllr(i, o);
-        } else if constexpr(constexpr_measure == OLLR) {
-            ret = cp ? llr(i, o, *cp): llr(i, o);
-            std::cerr << "Note: computing LLR, not OLLR, for this case\n";
         } else if constexpr(constexpr_measure == ITAKURA_SAITO) {
             ret = itakura_saito(i, o);
         } else if constexpr(constexpr_measure == REVERSE_ITAKURA_SAITO) {
@@ -464,12 +428,8 @@ public:
             ret = l1Norm(weighted_row(i) - weighted_row(j));
         } else if constexpr(constexpr_measure == L2) {
             ret = l2Norm(weighted_row(i) - weighted_row(j));
-        } else if constexpr(constexpr_measure == PL2) {
-            ret = p_l2norm(i, j);
         } else if constexpr(constexpr_measure == SQRL2) {
             ret = blaze::sqrNorm(weighted_row(i) - weighted_row(j));
-        } else if constexpr(constexpr_measure == PSL2) {
-            ret = blaze::sqrNorm(row(i) - row(j));
         } else if constexpr(constexpr_measure == JSD) {
             ret = jsd(i, j);
         } else if constexpr(constexpr_measure == JSM) {
@@ -478,16 +438,6 @@ public:
             ret = mkl(j, i);
         } else if constexpr(constexpr_measure == MKL) {
             ret = mkl(i, j);
-        } else if constexpr(constexpr_measure == EMD) {
-            throw NotImplementedError("Removed: currently, p_wasserstein functions are not permitted");
-            ret = p_wasserstein(row(i), row(j));
-        } else if constexpr(constexpr_measure == WEMD) {
-            throw NotImplementedError("Removed: currently, p_wasserstein functions are not permitted");
-            ret = p_wasserstein(weighted_row(i), weighted_row(j));
-        } else if constexpr(constexpr_measure == REVERSE_POISSON) {
-            ret = pkl(j, i);
-        } else if constexpr(constexpr_measure == POISSON) {
-            ret = pkl(i, j);
         } else if constexpr(constexpr_measure == HELLINGER) {
             ret = hellinger(i, j);
         } else if constexpr(constexpr_measure == BHATTACHARYYA_METRIC) {
@@ -498,8 +448,6 @@ public:
             ret = llr(i, j);
         } else if constexpr(constexpr_measure == UWLLR) {
             ret = uwllr(i, j);
-        } else if constexpr(constexpr_measure == OLLR) {
-            ret = ollr(i, j);
         } else if constexpr(constexpr_measure == ITAKURA_SAITO) {
             ret = itakura_saito(i, j);
         } else if constexpr(constexpr_measure == REVERSE_ITAKURA_SAITO) {
@@ -541,16 +489,10 @@ public:
             case L1: ret = call<L1>(o, i); break;
             case L2: ret = call<L2>(o, i); break;
             case SQRL2: ret = call<SQRL2>(o, i); break;
-            case PSL2: ret = call<PSL2>(o, i); break;
-            case PL2: ret = call<PL2>(o, i); break;
             case JSD: ret = call<JSD>(o, i); break;
             case JSM: ret = call<JSM>(o, i); break;
             case REVERSE_MKL: ret = call<REVERSE_MKL>(o, i, cache); break;
             case MKL: ret = call<MKL>(o, i, cache); break;
-            case EMD: ret = call<EMD>(o, i); break;
-            case WEMD: ret = call<WEMD>(o, i); break;
-            case REVERSE_POISSON: ret = call<REVERSE_POISSON>(o, i, cache); break;
-            case POISSON: ret = call<POISSON>(o, i, cache); break;
             case HELLINGER: ret = call<HELLINGER>(o, i, cache); break;
             case BHATTACHARYYA_METRIC: ret = call<BHATTACHARYYA_METRIC>(o, i); break;
             case BHATTACHARYYA_DISTANCE: ret = call<BHATTACHARYYA_DISTANCE>(o, i); break;
@@ -558,7 +500,6 @@ public:
             case SRLRT: ret = std::sqrt(call<LLR>(o, i, cache)); break;
             case UWLLR: ret = call<UWLLR>(o, i, cache); break;
             case SRULRT: ret = std::sqrt(call<UWLLR>(o, i, cache)); break;
-            case OLLR: ret = call<OLLR>(o, i, cache); break;
             case ITAKURA_SAITO: ret = call<ITAKURA_SAITO>(o, i, cache); break;
             case SYMMETRIC_ITAKURA_SAITO: ret = call<SYMMETRIC_ITAKURA_SAITO>(o, i, cache); break;
             case RSYMMETRIC_ITAKURA_SAITO: ret = call<RSYMMETRIC_ITAKURA_SAITO>(o, i, cache); break;
@@ -590,23 +531,16 @@ public:
             case TOTAL_VARIATION_DISTANCE: ret = call<TOTAL_VARIATION_DISTANCE>(i, o); break;
             case L1: ret = call<L1>(i, o); break;
             case L2: ret = call<L2>(i, o); break;
-            case PL2: ret = call<PL2>(i, o); break;
-            case PSL2: ret = call<PSL2>(i, o); break;
             case SQRL2: ret = call<SQRL2>(i, o); break;
             case JSD: ret = call<JSD>(i, o); break;
             case JSM: ret = call<JSM>(i, o); break;
             case REVERSE_MKL: ret = call<REVERSE_MKL>(i, o, cache); break;
             case MKL: ret = call<MKL>(i, o, cache); break;
-            case EMD: ret = call<EMD>(i, o); break;
-            case WEMD: ret = call<WEMD>(i, o); break;
-            case REVERSE_POISSON: ret = call<REVERSE_POISSON>(i, o, cache); break;
-            case POISSON: ret = call<POISSON>(i, o, cache); break;
             case HELLINGER: ret = call<HELLINGER>(i, o, cache); break;
             case BHATTACHARYYA_METRIC: ret = call<BHATTACHARYYA_METRIC>(i, o); break;
             case BHATTACHARYYA_DISTANCE: ret = call<BHATTACHARYYA_DISTANCE>(i, o); break;
             case LLR: ret = call<LLR>(i, o, cache); break;
             case UWLLR: ret = call<UWLLR>(i, o, cache); break;
-            case OLLR: ret = call<OLLR>(i, o, cache); break;
             case SRULRT: ret = std::sqrt(call<UWLLR>(i, o, cache)); break;
             case SRLRT: ret = std::sqrt(call<LLR>(i, o, cache)); break;
             case ITAKURA_SAITO: ret = call<ITAKURA_SAITO>(i, o, cache); break;
@@ -1782,19 +1716,18 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
             case LLR:
             case UWLLR:
             case ITAKURA_SAITO: case SIS: case REVERSE_ITAKURA_SAITO:
-            case REVERSE_POISSON: case REVERSE_MKL: case RSIS:
-            case POISSON:
+            case REVERSE_MKL: case RSIS:
             case MKL:
             {
                 if(tmpmulx.size() != nd) tmpmulx.resize(nd);
                 if(tmpmuly.size() != nd) tmpmuly.resize(nd);
                 tmpmulx = mr * lhrsi, tmpmuly = ctr * rhrsi;
                 FT klc;
-                if(msr == MKL || msr == POISSON) {
+                if(msr == MKL) {
                     klc = libkl::kl_reduce_aligned(tmpmulx.data(), tmpmuly.data(), nd, lhinc, rhinc);
                 } else if(msr == JSD || msr == JSM ) {
                     klc = libkl::jsd_reduce_aligned(tmpmulx.data(), tmpmuly.data(), nd, lhinc, rhinc);
-                } else if(msr == REVERSE_MKL || msr == REVERSE_POISSON) {
+                } else if(msr == REVERSE_MKL) {
                     klc = libkl::kl_reduce_aligned(tmpmuly.data(), tmpmulx.data(), nd, rhinc, lhinc);
                 } else if(msr == LLR || msr == UWLLR || msr == SRULRT || msr == SRLRT) {
                     auto bothsum = lhsum + rhsum;
@@ -1911,8 +1844,7 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
             case LLR:
             case UWLLR:
             case ITAKURA_SAITO: case SIS: case REVERSE_ITAKURA_SAITO:
-            case REVERSE_POISSON: case REVERSE_MKL: case RSIS:
-            case POISSON:
+            case REVERSE_MKL: case RSIS:
             case MKL:
             {
                 auto lhp = tmpmulx.data(), rhp = tmpmuly.data();
@@ -1923,13 +1855,13 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
                 const size_t nnz_either = lhp - tmpmulx.data();
                 assert(lhp - tmpmulx.data() == rhp - tmpmuly.data());
                 FT klc, zc;
-                if(msr == MKL || msr == POISSON) {
+                if(msr == MKL) {
                     klc = libkl::kl_reduce_aligned(tmpmulx.data(), tmpmuly.data(), nnz_either, lhinc, rhinc);
                     zc = sharednz * lhinc * (lhl - rhl);
                 } else if(msr == JSD || msr == JSM ) {
                     klc = libkl::jsd_reduce_aligned(tmpmulx.data(), tmpmuly.data(), nnz_either, lhinc, rhinc);
                     zc = ((lhincl + rhincl - shincl) * sharednz) * .5;
-                } else if(msr == REVERSE_MKL || msr == REVERSE_POISSON) {
+                } else if(msr == REVERSE_MKL) {
                     klc = libkl::kl_reduce_aligned(tmpmuly.data(), tmpmulx.data(), nnz_either, rhinc, lhinc);
                     zc = sharednz * rhinc * (rhl - lhl);
                 } else if(msr == LLR || msr == UWLLR || msr == SRULRT || msr == SRLRT) {

--- a/include/minicore/dist/distance.h
+++ b/include/minicore/dist/distance.h
@@ -28,20 +28,17 @@ enum DissimilarityMeasure {
     JSM, // Multinomial Jensen-Shannon Metric
     JSD, // Multinomial Jensen-Shannon Divergence
     MKL, // Multinomial KL Divergence
-    POISSON, // Poisson KL
     HELLINGER,
     BHATTACHARYYA_METRIC,
     BHATTACHARYYA_DISTANCE,
     TOTAL_VARIATION_DISTANCE,
     LLR,
     REVERSE_MKL,
-    REVERSE_POISSON,
     UWLLR, /* Unweighted Log-likelihood Ratio.
             * Specifically, this is the D_{JSD}^{\lambda}(x, y),
             * where \lambda = \frac{N_p}{N_p + N_q}
             *
             */
-    OLLR,       // Old LLR, deprecated (included for compatibility/comparisons)
     ITAKURA_SAITO, // \sum_{i=1}^D[\frac{a_i}{b_i} - \log{\frac{a_i}{b_i}} - 1]
     REVERSE_ITAKURA_SAITO, // Reverse I-S
     COSINE_DISTANCE,             // Cosine distance
@@ -50,19 +47,14 @@ enum DissimilarityMeasure {
     PROBABILITY_COSINE_SIMILARITY,
     DOT_PRODUCT_SIMILARITY,
     PROBABILITY_DOT_PRODUCT_SIMILARITY,
-    EMD,
-    WEMD, // Weighted Earth-mover's distance
     ORACLE_METRIC,
     ORACLE_PSEUDOMETRIC,
-    PL2,
-    PSL2,
     SYMMETRIC_ITAKURA_SAITO,
     REVERSE_SYMMETRIC_ITAKURA_SAITO,
     SRLRT,
     SRULRT,
     WLLR = LLR, // Weighted Log-likelihood Ratio, now equivalent to the LLR
     TVD = TOTAL_VARIATION_DISTANCE,
-    WASSERSTEIN=EMD,
     PSD = JSD, // Poisson JSD, but algebraically equivalent
     PSM = JSM,
     IS=ITAKURA_SAITO,
@@ -76,7 +68,7 @@ static constexpr inline bool msr_is_normalized(DissimilarityMeasure msr) {
         case IS: case SIS: case RSIS: case REVERSE_ITAKURA_SAITO: case TVD:
         case MKL: case REVERSE_MKL: case COSINE_DISTANCE: case COSINE_SIMILARITY:
         case HELLINGER: case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
-        case POISSON: case REVERSE_POISSON: case JSM: case JSD:
+        case JSM: case JSD:
             return true;
 
         case LLR:
@@ -94,7 +86,6 @@ inline namespace detail {
  *     1. Logs  (needs_logs)
  *     2. Sqrts (needs_sqrt)
  *     3. L2 norms (needs_l2_cache)
- *     4. PL2 norms (needs_probability_l2_cache)
  * 2. Whether the measure satisfies:
  *     1. Being a Bregman divergence (is_bregman)
  *     2. Being a distance metric (satisfies_metric)
@@ -122,8 +113,8 @@ inline namespace detail {
 
 static constexpr INLINE bool is_bregman(DissimilarityMeasure d)  {
     switch(d) {
-        case JSD: case MKL: case POISSON: case ITAKURA_SAITO:
-        case REVERSE_MKL: case REVERSE_POISSON: case REVERSE_ITAKURA_SAITO:
+        case JSD: case MKL: case ITAKURA_SAITO:
+        case REVERSE_MKL: case REVERSE_ITAKURA_SAITO:
         case SYMMETRIC_ITAKURA_SAITO: case REVERSE_SYMMETRIC_ITAKURA_SAITO:
         case SQRL2: case SRLRT: case SRULRT:
         return true;
@@ -132,7 +123,7 @@ static constexpr INLINE bool is_bregman(DissimilarityMeasure d)  {
     return false;
 }
 static constexpr INLINE bool satisfies_d2(DissimilarityMeasure d) {
-    return d == LLR || d == UWLLR || d == OLLR || is_bregman(d) || d == PSL2;
+    return d == LLR || d == UWLLR || is_bregman(d);
 }
 static constexpr INLINE bool satisfies_metric(DissimilarityMeasure d) {
     switch(d) {
@@ -143,7 +134,6 @@ static constexpr INLINE bool satisfies_metric(DissimilarityMeasure d) {
         case TOTAL_VARIATION_DISTANCE:
         case HELLINGER:
         case ORACLE_METRIC:
-        case PL2:
         case SRLRT: case SRULRT: // Not sure, but probably
             return true;
         default: ;
@@ -153,11 +143,10 @@ static constexpr INLINE bool satisfies_metric(DissimilarityMeasure d) {
 static constexpr INLINE bool satisfies_rho_metric(DissimilarityMeasure d) {
     if(satisfies_metric(d)) return true;
     switch(d) {
-        case PSL2:  // rho = 2
         case SQRL2: // rho = 2
         // These three don't, technically, but using a prior can force it to follow it on real data
         case ORACLE_PSEUDOMETRIC:
-        case LLR: case UWLLR: case OLLR: case SYMMETRIC_ITAKURA_SAITO: case REVERSE_SYMMETRIC_ITAKURA_SAITO:
+        case LLR: case UWLLR: case SYMMETRIC_ITAKURA_SAITO: case REVERSE_SYMMETRIC_ITAKURA_SAITO:
             return true;
         default:;
     }
@@ -166,9 +155,9 @@ static constexpr INLINE bool satisfies_rho_metric(DissimilarityMeasure d) {
 
 static constexpr INLINE bool needs_logs(DissimilarityMeasure d)  {
     switch(d) {
-        case JSM: case JSD: case MKL: case POISSON: case LLR: case OLLR: case ITAKURA_SAITO:
+        case JSM: case JSD: case MKL: case LLR: case ITAKURA_SAITO:
         case SRLRT: case SRULRT:
-        case REVERSE_MKL: case REVERSE_POISSON: case UWLLR: case REVERSE_ITAKURA_SAITO: case SYMMETRIC_ITAKURA_SAITO: case REVERSE_SYMMETRIC_ITAKURA_SAITO: return true;
+        case REVERSE_MKL: case UWLLR: case REVERSE_ITAKURA_SAITO: case SYMMETRIC_ITAKURA_SAITO: case REVERSE_SYMMETRIC_ITAKURA_SAITO: return true;
         default: break;
     }
     return false;
@@ -179,13 +168,11 @@ static constexpr INLINE bool use_scaled_centers(DissimilarityMeasure measure) {
     // compared to default behavior
     switch(measure) {
         case LLR:
-        case OLLR:
         case UWLLR:
         case L1:
         case SQRL2:
         case L2:
         case COSINE_DISTANCE:
-        case WEMD:
         case SYMMETRIC_ITAKURA_SAITO:
         case RSYMMETRIC_ITAKURA_SAITO:
            return true;
@@ -197,9 +184,9 @@ static constexpr INLINE bool is_probability(DissimilarityMeasure d)  {
     switch(d) {
         case TOTAL_VARIATION_DISTANCE: case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
         case HELLINGER:
-        case MKL: case POISSON: case REVERSE_MKL: case REVERSE_POISSON:
+        case MKL: case REVERSE_MKL:
         case PROBABILITY_COSINE_DISTANCE: case PROBABILITY_DOT_PRODUCT_SIMILARITY:
-        case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO: case PSL2: case PL2:
+        case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
         case SYMMETRIC_ITAKURA_SAITO:
         case RSYMMETRIC_ITAKURA_SAITO:
         return true;
@@ -218,14 +205,12 @@ static constexpr bool expects_nonnegative(DissimilarityMeasure measure) {
         case COSINE_DISTANCE: case COSINE_SIMILARITY:
         case PROBABILITY_COSINE_DISTANCE: case PROBABILITY_COSINE_SIMILARITY:
         case DOT_PRODUCT_SIMILARITY:
-        case WEMD: case EMD: case ORACLE_METRIC: case ORACLE_PSEUDOMETRIC: return false;
 
         default: // Unexpected, but will assume it's required.
-        case JSM: case JSD: case MKL: case POISSON: case HELLINGER: case BHATTACHARYYA_METRIC:
+        case JSM: case JSD: case MKL: case HELLINGER: case BHATTACHARYYA_METRIC:
         case BHATTACHARYYA_DISTANCE: case TOTAL_VARIATION_DISTANCE: case LLR:
-        case REVERSE_MKL: case REVERSE_POISSON: case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
+        case REVERSE_MKL: case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
         case PROBABILITY_DOT_PRODUCT_SIMILARITY:
-        case PL2: case PSL2:
         case SYMMETRIC_ITAKURA_SAITO:
         case RSYMMETRIC_ITAKURA_SAITO:
         return true;
@@ -253,13 +238,12 @@ static constexpr INLINE bool  needs_sqrt(DissimilarityMeasure d) {
 
 static constexpr INLINE bool is_symmetric(DissimilarityMeasure d) {
     switch(d) {
-        case L1: case L2: case EMD: case HELLINGER: case BHATTACHARYYA_DISTANCE: case BHATTACHARYYA_METRIC:
-        case JSD: case JSM: case LLR: case UWLLR: case SQRL2: case TOTAL_VARIATION_DISTANCE: case OLLR:
+        case L1: case L2: case HELLINGER: case BHATTACHARYYA_DISTANCE: case BHATTACHARYYA_METRIC:
+        case JSD: case JSM: case LLR: case UWLLR: case SQRL2: case TOTAL_VARIATION_DISTANCE:
         case COSINE_DISTANCE: case COSINE_SIMILARITY:
         case PROBABILITY_COSINE_DISTANCE: case PROBABILITY_COSINE_SIMILARITY:
         case SYMMETRIC_ITAKURA_SAITO:
         case RSYMMETRIC_ITAKURA_SAITO:
-        case PL2: case PSL2:
         case SRULRT: case SRLRT:
             return true;
         default: ;
@@ -290,20 +274,16 @@ static constexpr INLINE const char *prob2str(DissimilarityMeasure d) {
     switch(d) {
         case BHATTACHARYYA_DISTANCE: return "BHATTACHARYYA_DISTANCE";
         case BHATTACHARYYA_METRIC: return "BHATTACHARYYA_METRIC";
-        case EMD: return "EMD";
         case HELLINGER: return "HELLINGER";
         case JSD: return "JSD";
         case JSM: return "JSM";
         case L1: return "L1";
         case L2: return "L2";
         case LLR: return "LLR";
-        case OLLR: return "OLLR";
         case UWLLR: return "UWLLR";
         case ITAKURA_SAITO: return "ITAKURA_SAITO";
         case MKL: return "MKL";
-        case POISSON: return "POISSON";
         case REVERSE_MKL: return "REVERSE_MKL";
-        case REVERSE_POISSON: return "REVERSE_POISSON";
         case REVERSE_ITAKURA_SAITO: return "REVERSE_ITAKURA_SAITO";
         case SQRL2: return "SQRL2";
         case TOTAL_VARIATION_DISTANCE: return "TOTAL_VARIATION_DISTANCE";
@@ -315,8 +295,6 @@ static constexpr INLINE const char *prob2str(DissimilarityMeasure d) {
         case ORACLE_PSEUDOMETRIC: return "ORACLE_PSEUDOMETRIC";
         case SRULRT: return "SRULRT";
         case SRLRT: return "SRLRT";
-        case PSL2: return "PSL2";
-        case PL2: return "PL2";
         case SYMMETRIC_ITAKURA_SAITO: return "SYMMETRIC_ITAKURA_SAITO";
         case RSYMMETRIC_ITAKURA_SAITO: return "RSYMMETRIC_ITAKURA_SAITO";
         default: return "INVALID TYPE";
@@ -329,19 +307,15 @@ static constexpr INLINE const char *prob2desc(DissimilarityMeasure d) {
     switch(d) {
         case BHATTACHARYYA_DISTANCE: return "Bhattacharyya distance: -log(dot(sqrt(x) * sqrt(y)))";
         case BHATTACHARYYA_METRIC: return "Bhattacharyya metric: sqrt(1 - BhattacharyyaSimilarity(x, y))";
-        case EMD: return "Earth Mover's Distance: Optimal Transport";
         case HELLINGER: return "Hellinger Distance: sqrt(sum((sqrt(x) - sqrt(y))^2))/2";
         case JSD: return "Jensen-Shannon Divergence for Poisson and Multinomial models, for which they are equivalent";
         case JSM: return "Jensen-Shannon Metric, known as S2JSD and the Endres metric, for Poisson and Multinomial models, for which they are equivalent";
         case L1: return "L1 distance";
         case L2: return "L2 distance";
         case LLR: return "Log-likelihood Ratio under the multinomial model";
-        case OLLR: return "Original log-likelihood ratio. This is likely not correct, but it is related to the Jensen-Shannon Divergence";
         case UWLLR: return "Unweighted Log-likelihood Ratio. This is effectively the Generalized Jensen-Shannon Divergence with lambda parameter corresponding to the fractional contribution of counts in the first observation. This is symmetric, unlike the G_JSD, because the parameter comes from the counts.";
         case MKL: return "Multinomial KL divergence";
-        case POISSON: return "Poisson KL Divergence";
         case REVERSE_MKL: return "Reverse Multinomial KL divergence";
-        case REVERSE_POISSON: return "Reverse KL divergence";
         case SQRL2: return "Squared L2 Norm";
         case TOTAL_VARIATION_DISTANCE: return "Total Variation Distance: 1/2 sum_{i in D}(|x_i - y_i|)";
         case ITAKURA_SAITO: return "Itakura-Saito divergence, a Bregman divergence [sum((a / b) - log(a / b) - 1 for a, b in zip(A, B))]";
@@ -354,8 +328,6 @@ static constexpr INLINE const char *prob2desc(DissimilarityMeasure d) {
         case PROBABILITY_COSINE_SIMILARITY: return "Cosine similarity of the probability vectors: \\frac{A \\cdot B}{|A|_2 |B|_2}";
         case ORACLE_METRIC: return "Placeholder for oracle metrics, allowing us to use DissimilarityMeasure in other situations";
         case ORACLE_PSEUDOMETRIC: return "Placeholder for oracle pseudometrics";
-        case PSL2: return "Probability squared L2 norm, k-means in probabilityspace";
-        case PL2: return "Probability L2 norm";
         case SRULRT: return "Square root of UWLLR, unweighted log likelihood ratio test; likely a metric: related to the JSM and Generalized JSD";
         case SRLRT: return "Square root of LRT, the log likelihood ratio test; likely a metric: related to the JSM and Generalized JSD";
         default: return prob2str(d);
@@ -369,7 +341,6 @@ static constexpr DissimilarityMeasure USABLE_MEASURES []  {
     JSM,
     JSD,
     MKL,
-    POISSON,
     HELLINGER,
     BHATTACHARYYA_METRIC,
     BHATTACHARYYA_DISTANCE,
@@ -377,19 +348,15 @@ static constexpr DissimilarityMeasure USABLE_MEASURES []  {
     LLR,
     UWLLR,
     REVERSE_MKL,
-    REVERSE_POISSON,
     ITAKURA_SAITO,
     REVERSE_ITAKURA_SAITO,
     COSINE_DISTANCE,
     COSINE_SIMILARITY,
-    PL2,
-    PSL2,
     SYMMETRIC_ITAKURA_SAITO,
     RSYMMETRIC_ITAKURA_SAITO,
     SRLRT,
     SRULRT
     // Absent:
-    // EMD/WEMB -- lacking proper evaluation
     // PROBABILITY_COSINE_DISTANCE/PROBABILITY_COSINE_SIMILARITY -- extensions to this space are not complete.
     // ORACLE_METRIC/ORACLE_PSEUDOMETRIC, as they are placeholders
 };
@@ -408,16 +375,16 @@ static void print_measures() {
 static constexpr bool is_valid_measure(DissimilarityMeasure measure) {
     switch(measure) {
         case L1: case L2: case SQRL2: case JSM: case JSD: case MKL:
-        case POISSON: case HELLINGER: case BHATTACHARYYA_METRIC:
+        case HELLINGER: case BHATTACHARYYA_METRIC:
         case BHATTACHARYYA_DISTANCE: case TOTAL_VARIATION_DISTANCE:
-        case UWLLR: case LLR: case REVERSE_MKL: case REVERSE_POISSON: case REVERSE_ITAKURA_SAITO:
+        case UWLLR: case LLR: case REVERSE_MKL: case REVERSE_ITAKURA_SAITO:
         case ITAKURA_SAITO: case COSINE_DISTANCE: case PROBABILITY_COSINE_DISTANCE:
         case DOT_PRODUCT_SIMILARITY: case PROBABILITY_DOT_PRODUCT_SIMILARITY:
-        case EMD: case WEMD: case ORACLE_METRIC: case ORACLE_PSEUDOMETRIC:
+        case ORACLE_METRIC: case ORACLE_PSEUDOMETRIC:
         case SYMMETRIC_ITAKURA_SAITO:
         case RSYMMETRIC_ITAKURA_SAITO:
         case SRLRT: case SRULRT:
-        case PL2: case PSL2: return true;
+        return true;
         default: ;
     }
     return false;

--- a/include/minicore/dist/distance.h
+++ b/include/minicore/dist/distance.h
@@ -76,8 +76,11 @@ static constexpr inline bool msr_is_normalized(DissimilarityMeasure msr) {
         case IS: case SIS: case RSIS: case REVERSE_ITAKURA_SAITO: case TVD:
         case MKL: case REVERSE_MKL: case COSINE_DISTANCE: case COSINE_SIMILARITY:
         case HELLINGER: case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
-        case POISSON: case REVERSE_POISSON: case JSM: case JSD: case UWLLR: case SRULRT: return true;
-        case SRLRT: case LLR: case L1: case L2: case SQRL2:
+        case POISSON: case REVERSE_POISSON: case JSM: case JSD: case UWLLR: case SRULRT:
+            return true;
+
+        case LLR:
+        case SRLRT: case L1: case L2: case SQRL2:
         default:
         return false;
     }

--- a/include/minicore/dist/distance.h
+++ b/include/minicore/dist/distance.h
@@ -76,11 +76,11 @@ static constexpr inline bool msr_is_normalized(DissimilarityMeasure msr) {
         case IS: case SIS: case RSIS: case REVERSE_ITAKURA_SAITO: case TVD:
         case MKL: case REVERSE_MKL: case COSINE_DISTANCE: case COSINE_SIMILARITY:
         case HELLINGER: case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
-        case POISSON: case REVERSE_POISSON: case JSM: case JSD: case UWLLR: case SRULRT:
+        case POISSON: case REVERSE_POISSON: case JSM: case JSD:
             return true;
 
         case LLR:
-        case SRLRT: case L1: case L2: case SQRL2:
+        case SRLRT: case L1: case L2: case SQRL2: case UWLLR: case SRULRT:
         default:
         return false;
     }

--- a/include/minicore/dist/knngraph.h
+++ b/include/minicore/dist/knngraph.h
@@ -226,6 +226,7 @@ auto knng2mst(const Graph &gr) {
     return ret;
 }
 
+
 #if 0
 template<typename IT=uint32_t, typename MatrixType>
 auto perform_rcc(const jsd::DissimilarityApplicator<MatrixType> &app, unsigned k, bool mutual=true, size_t niter=100) {

--- a/include/minicore/optim/kmeans.h
+++ b/include/minicore/optim/kmeans.h
@@ -127,6 +127,86 @@ kmeanspp(const Oracle &oracle, RNG &rng, size_t np, size_t k, const WFT *weights
     std::fprintf(stderr, "returning %zu centers and %zu assignments\n", centers.size(), assignments.size());
     return std::make_tuple(std::move(centers), std::move(assignments), std::vector<FT>(distances.begin(), distances.end()));
 }
+#if 0
+template<typename Oracle, typename FT=double,
+         typename IT=std::uint32_t, typename RNG, typename WFT=FT>
+auto
+batched_kmeanspp(const Oracle &oracle, RNG &rng, size_t np, size_t k, int batchsize, double max_degradation=0.1, const WFT *weights=nullptr, size_t lspprounds=0, bool use_exponential_skips=false) {
+    std::fprintf(stderr, "Starting %s with np = %zu and k = %zu%s, with batchsize=%d and %g max degradation.\n", __PRETTY_FUNCTION__, np, k, weights ? " and non-null weights": "", batchsize, max_degradation);
+    std::vector<IT> centers(k, IT(0));
+    blz::DV<FT> distances(np, std::numeric_limits<FT>::max());
+    {
+        auto fc = rng() % np;
+        centers[0] = fc;
+        distances = blaze::generate(np,[&](auto i) __attribute__((always_inline)) {
+            if(unlikely(i == fc)) return FT(0.);
+            return FT(oracle(fc, i));
+        });
+        assert(distances[fc] == 0.);
+    }
+    std::vector<IT> assignments(np, IT(0));
+    std::uniform_real_distribution<double> urd;
+    blz::DV<FT> rvals;
+    // Short of re-writing the loop fully with SIMD-optimized argmin
+    // and performing one single pass through all the data
+    // (which is less important if dimensionaliy is high)
+    // this is as optimized as it can be.
+    // At least it's all embarassingly parallelizable
+    const SampleFmt fmt = use_exponential_skips ? USE_EXPONENTIAL_SKIPS: NEITHER;
+    std::vector<uint64_t> sampled_ids(kperbatch);
+    for(size_t center_idx = 1;center_idx < k;) {
+        DBG_ONLY(std::fprintf(stderr, "Centers size: %zu/%zu. Newest center: %u\r\n", center_idx, size_t(k), centers[center_idx - 1]);)
+        // At this point, the cdf has been prepared, and we are ready to sample.
+        // add new element
+        auto cd = centers.data(), ce = cd + center_idx;
+        setnewc:
+        if(weights) {
+            auto w = blz::make_cv(weights, np);
+            rvals = w * distances;
+            reservoir_simd::sample_k(rvals.data(), np, k, sampled_ids.data(), rng());
+        } else {
+            reservoir_simd::sample_k(distances.data(), np, k, sampled_ids.data(), rng());
+        }
+        if(unlikely(distances[newc] == 0.)) {
+            std::fprintf(stderr, "Selected point of weight 0 (this should not happen unless there are negative or infinite weights): %zu\n", size_t(newc));
+            if(++d0s == 5) {
+                std::stringstream ss;
+                ss << trans(distances) << ", with max " << distances[newc] << '\n';
+                const std::string msg = std::move(ss.str());
+                bool success = std::fwrite(msg.data(), msg.size(), 1, stderr) == 1u;
+                throw std::runtime_error(std::string("Unexpected: distance of 0 selected") + msg + (success ? "": "writing to stderr failed"));
+            }
+            goto setnewc;
+        }
+        if(std::find(cd, ce, newc) != ce) {
+            std::fprintf(stderr, "Re-selected existing center %u. Continuing...\n", int(newc));
+            continue;
+        }
+        assignments[newc] = center_idx;
+        centers[center_idx] = newc;
+        distances[newc] = 0.;
+        OMP_PFOR_DYN
+        for(size_t i = 0; i < np; ++i) {
+            auto &ldist = distances[i];
+            if(ldist == 0.) continue;
+            auto dist = oracle(newc, i);
+            if(dist < ldist) { // Only write if it changed
+                assignments[i] = center_idx;
+                ldist = dist;
+            }
+        }
+        ++center_idx;
+    }
+
+    std::fprintf(stderr, "Completed kmeans++ with centers of size %zu\n", centers.size());
+    if(lspprounds > 0) {
+        std::fprintf(stderr, "Performing %u rounds of ls++\n", int(lspprounds));
+        localsearchpp_rounds(oracle, rng, distances, centers, assignments, np, lspprounds, weights);
+    }
+    std::fprintf(stderr, "returning %zu centers and %zu assignments\n", centers.size(), assignments.size());
+    return std::make_tuple(std::move(centers), std::move(assignments), std::vector<FT>(distances.begin(), distances.end()));
+}
+#endif
 
 template<typename Iter, typename FT=double,
          typename IT=std::uint32_t, typename RNG, typename Norm=sqrL2Norm, typename WFT=FT>

--- a/include/minicore/optim/kmedian.h
+++ b/include/minicore/optim/kmedian.h
@@ -299,7 +299,7 @@ static inline void weighted_median(const blz::Matrix<MT, SO> &data, blz::Vector<
         {
             return x.first < y;
         });
-        __assign(*ret, i, it->first == mid ? FT(.5 * (it->first + it[1].first)): FT(it[1].first));
+        (*ret)[i] = it->first == mid ? FT(.5 * (it->first + it[1].first)): FT(it[1].first);
     }
 }
 

--- a/include/minicore/optim/lsearchpp.h
+++ b/include/minicore/optim/lsearchpp.h
@@ -22,7 +22,9 @@ auto localsearchpp_rounds(const Oracle &oracle, RNG &rng, DistC &distances, Ctrs
     using value_type = std::decay_t<decltype(*std::begin(distances))>;
     std::uniform_real_distribution<value_type> dist;
     const unsigned k = ctrs.size();
-    blz::DM<value_type> ctrcostmat = blaze::generate(np, k, [&](auto x, auto y) {
+    diskmat::PolymorphicMat<value_type> diskctrcostmat(np, k);
+    auto &ctrcostmat = ~diskctrcostmat;
+    ctrcostmat = blaze::generate(np, k, [&](auto x, auto y) {
         return oracle(x, ctrs[y]);
     });
     DBG_ONLY(std::fprintf(stderr, "np: %zu\n", np);)

--- a/include/minicore/optim/lsearchpp.h
+++ b/include/minicore/optim/lsearchpp.h
@@ -11,6 +11,7 @@
 #include "minicore/util/exception.h"
 #include "libsimdsampling/simdsampling.ho.h"
 #include "libsimdsampling/argminmax.ho.h"
+#include "diskmat/diskmat.h"
 
 namespace minicore {
 

--- a/include/minicore/util/csc.h
+++ b/include/minicore/util/csc.h
@@ -1000,7 +1000,17 @@ inline decltype(auto) sum(const CSparseMatrix<VT, IT, IPtrT> &sm) {
             }
         );
     } else {
-        throw NotImplementedError("Not supported: columnwise sums\n");
+        blaze::DynamicVector<VT, blz::rowVector> sums(sm.columns());
+        OMP_PFOR
+        for(size_t i = 0; i < sm.rows(); ++i) {
+            auto r = row(sm, i);
+            #pragma GCC unroll 4
+            for(size_t i = 0; i < r.n_; ++i) {
+                OMP_ATOMIC
+                sums[r.indices_[i]] += r.data_[i];
+            }
+        }
+        return sums;
     }
 }
 

--- a/include/minicore/util/csc.h
+++ b/include/minicore/util/csc.h
@@ -409,10 +409,10 @@ struct ProdCSparseVector {
             return ret;
         }
         const ViewType &operator*() const {
-            return this;
+            return *this;
         }
         ViewType &operator*() {
-            return this;
+            return *this;
         }
         ViewType *operator->() {
             return this;

--- a/include/minicore/util/csc.h
+++ b/include/minicore/util/csc.h
@@ -336,6 +336,8 @@ struct ProdCSparseVector {
 
     ProdCSparseVector(const CSparseVector<VT, IT> &ovec, double prod): data_(ovec.data_), indices_(ovec.indices_), n_(ovec.n_), dim_(ovec.dim_), prod_(prod) {
     }
+    ProdCSparseVector(const ProdCSparseVector<VT, IT> &ovec, double prod): data_(ovec.data_), indices_(ovec.indices_), n_(ovec.n_), dim_(ovec.dim_), prod_(prod * ovec.prod_) {
+    }
     size_t nnz() const {return n_;}
     size_t size() const {return dim_;}
     using NCVT = std::remove_const_t<VT>;
@@ -465,8 +467,11 @@ ProdCSparseVector<VT, IT> operator*(const CSparseVector<VT, IT> &lhs, OVT rhs) {
 
 template<typename VT, typename IT, typename OVT>
 ProdCSparseVector<VT, IT> operator/(const CSparseVector<VT, IT> &lhs, OVT rhs) {
-    VT mult = VT(1) / rhs;
-    return lhs * mult;
+    return lhs * double(1. / rhs);
+}
+template<typename VT, typename IT, typename OVT>
+ProdCSparseVector<VT, IT> operator/(const ProdCSparseVector<VT, IT> &lhs, OVT rhs) {
+    return ProdCSparseVector<VT, IT>(lhs, 1. / rhs);
 }
 
 template<typename VT1, typename IT1, typename VT2, bool TF>

--- a/python/README.md
+++ b/python/README.md
@@ -27,7 +27,12 @@ shape = # np array or tuple
 
 assert len(data) == len(indices)
 
-mcmat = mc.SparseMatrixWrapper(mc.csr_tuple(data=data, indices=indices, indptr=indptr, shape=shape, nnz=len(data)))
+csrtup = mc.csr_tuple(data=data, indices=indices, indptr=indptr, shape=shape, nnz=len(data))
+
+mcmat = mc.SparseMatrixWrapper(csrtup)
+
+# We could also produce one without copying:
+csrmat = mc.CSparseMatrix(csrtup)
 
 k = 50
 beta = 0.5   # Pseudocount prior for Bregman divergences
@@ -40,7 +45,7 @@ ntimes = 2   # Perform kmeans++ sampling %i times, use the best-scoring set of c
 
 seed = 0     # if seed is not set, defaults to 0. Results will be identical with the same seed.
 
-measure = "REVERSE_MKL" # See https://github.com/dnbaker/minicore/blob/main/docs/msr.md for examples/integer codes
+measure = "MKL" # See https://github.com/dnbaker/minicore/blob/main/docs/msr.md for examples/integer codes
                         # value can be integral or be the short string description
                         # MKL = reverse categorical KL divergence
 
@@ -56,8 +61,8 @@ lspprounds = 2 # Perform %i rounds of localsearch++. Yields a higher quality set
 
 ctr_rows = mc.rowsel(centers)
 
-res = mc.cluster(mcmat, ctr_rows, betaprior=beta, msr=measure,
-                              weights=weights, lspprounds=lspprounds, seed=seed)
+res = mc.hcluster(mcmat, ctr_rows, betaprior=beta, msr=measure,
+                  weights=weights, lspprounds=lspprounds, seed=seed)
 
 
 # res is a dictionary with the following keys:

--- a/python/minicore/__init__.py
+++ b/python/minicore/__init__.py
@@ -5,8 +5,8 @@ from .constants import CSR as csr_tuple, KMCRSV
 from pyminicore import SparseMatrixWrapper as smw
 import numpy as np
 
-cluster_from_centers = pyminicore.cluster
+cluster_from_centers = pyminicore.hcluster
 
-def spctrlist2mat(centertups, nc):
+def ctrs2sp(centertups, nc):
     import scipy.sparse as sp
     return sp.vstack([sp.csr_matrix((x[0],[0] * len(x[0]), [0, len(x[0])]), shape=[1, nc]) for x in centertups])

--- a/python/pycluster.cpp
+++ b/python/pycluster.cpp
@@ -4,6 +4,7 @@
 
 
 
+#if 0
 py::object func1(const SparseMatrixWrapper &smw, py::int_ k, double beta,
                  py::object msr, py::object weights, double eps,
                  int ntimes, uint64_t seed, int lspprounds, int kmcrounds, uint64_t kmeansmaxiter)
@@ -46,19 +47,19 @@ py::object func1(const SparseMatrixWrapper &smw, py::int_ k, double beta,
     }
     throw std::invalid_argument("Weights were not float, double, or None.");
 }
+#endif
 
 
 void init_clustering(py::module &m) {
 
-    m.def("cluster", [](SparseMatrixWrapper &smw, py::object centers, double beta,
-                    py::object msr, py::object weights, double eps,
-                    uint64_t kmeansmaxiter, uint64_t seed, Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                    Py_ssize_t reseed_count, bool with_rep) {
-                        return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
-                            //kmcrounds, ntimes, lspprounds,
-                            seed,
-                            mbsize, ncheckins, reseed_count, with_rep);
-                    },
+    m.def("hcluster", [](SparseMatrixWrapper &smw, py::object centers, double beta,
+                         py::object msr, py::object weights, double eps,
+                         uint64_t kmeansmaxiter, uint64_t seed, Py_ssize_t mbsize, Py_ssize_t ncheckins,
+                         Py_ssize_t reseed_count, bool with_rep) {
+                             return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
+                                 seed,
+                                 mbsize, ncheckins, reseed_count, with_rep);
+                         },
     py::arg("smw"),
     py::arg("centers"),
     py::arg("prior") = 0.,

--- a/python/pycluster.cpp
+++ b/python/pycluster.cpp
@@ -58,7 +58,7 @@ void init_clustering(py::module &m) {
                          Py_ssize_t reseed_count, bool with_rep) {
                              return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
                                  seed,
-                                 mbsize, ncheckins, reseed_count, with_rep);
+                                 mbsize, ncheckins, reseed_count, with_rep, use_cs);
                          },
     py::arg("smw"),
     py::arg("centers"),
@@ -71,6 +71,6 @@ void init_clustering(py::module &m) {
     py::arg("mbsize") = Py_ssize_t(-1),
     py::arg("ncheckins") = Py_ssize_t(-1),
     py::arg("reseed_count") = Py_ssize_t(5),
-    py::arg("with_rep") = false,
+    py::arg("with_rep") = false, py::arg("use_cs") = false,
     "Clusters a SparseMatrixWrapper object using settings and the centers provided above; set prior to < 0 for it to be 1 / ncolumns(). Performs seeding, followed by EM or minibatch k-means");
 } // init_clustering

--- a/python/pycluster.cpp
+++ b/python/pycluster.cpp
@@ -55,7 +55,7 @@ void init_clustering(py::module &m) {
     m.def("hcluster", [](SparseMatrixWrapper &smw, py::object centers, double beta,
                          py::object msr, py::object weights, double eps,
                          uint64_t kmeansmaxiter, uint64_t seed, Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                         Py_ssize_t reseed_count, bool with_rep) {
+                         Py_ssize_t reseed_count, bool with_rep, bool use_cs) {
                              return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
                                  seed,
                                  mbsize, ncheckins, reseed_count, with_rep, use_cs);

--- a/python/pycluster.h
+++ b/python/pycluster.h
@@ -149,7 +149,7 @@ py::object __py_cluster_from_centers(const Matrix &smw,
             double bestcost;
             uint32_t bestind;
                 auto r = row(mat, idx);
-                const double rsum = sum(r);
+                const double rsum = rsums[idx];
                 bestind = 0;
                 auto c = cmp::msr_with_prior<ComputeT>(measure, r, dvecs[0], prior, psum, rsum, centersums[0]);
                 for(unsigned j = 1; j < k; ++j) {

--- a/python/pycluster_csr.cpp
+++ b/python/pycluster_csr.cpp
@@ -1,21 +1,8 @@
 #include "pycluster.h"
 
-#if BUILD_CSR_CLUSTERING
-
-#if 0
-py::object cluster1_csr(const PyCSparseMatrix &smw, py::int_ k, double beta,
-                 py::object msr, py::object weights, double eps,
-                 int ntimes, uint64_t seed, int lspprounds, int kmcrounds, uint64_t kmeansmaxiter)
-{
-    return func1(smw, k, beta, msr, weights, eps, ntimes, seed, lspprounds, kmcrounds, kmeansmaxiter);
-}
-#endif
-
-#endif
-
 void init_clustering_csr(py::module &m) {
 #if BUILD_CSR_CLUSTERING
-    m.def("cluster", [](const PyCSparseMatrix &smw, py::object centers, double beta,
+    m.def("hcluster", [](const PyCSparseMatrix &smw, py::object centers, double beta,
                     py::object msr, py::object weights, double eps,
                     uint64_t kmeansmaxiter,
                         //size_t kmcrounds, int ntimes, int lspprounds,

--- a/python/pycluster_csr.cpp
+++ b/python/pycluster_csr.cpp
@@ -8,12 +8,12 @@ void init_clustering_csr(py::module &m) {
                         //size_t kmcrounds, int ntimes, int lspprounds,
                     uint64_t seed,
                     Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                    Py_ssize_t reseed_count, bool with_rep) -> py::object
+                    Py_ssize_t reseed_count, bool with_rep, bool use_cs) -> py::object
     {
         return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
                 //kmcrounds, ntimes, lspprounds,
                 seed,
-                mbsize, ncheckins, reseed_count, with_rep);
+                mbsize, ncheckins, reseed_count, with_rep, use_cs);
     },
     py::arg("smw"),
     py::arg("centers"),
@@ -26,7 +26,8 @@ void init_clustering_csr(py::module &m) {
     py::arg("mbsize") = Py_ssize_t(-1),
     py::arg("ncheckins") = Py_ssize_t(-1),
     py::arg("reseed_count") = Py_ssize_t(5),
-    py::arg("with_rep") = false
+    py::arg("with_rep") = false,
+    py::arg("use_cs") = false
     );
 
 #endif

--- a/python/pycluster_soft.h
+++ b/python/pycluster_soft.h
@@ -85,7 +85,6 @@ py::dict py_scluster(const Matrix &smw,
                void *weights = (void *)nullptr,
                std::string wfmt="f")
 {
-    std::fprintf(stderr, "temp=%g, beta=%g\n", temp, beta);
     assert(beta > 0.);
     py::dict retdict;
     py::object asns = py::none(), costs = py::none();

--- a/python/pycluster_soft.h
+++ b/python/pycluster_soft.h
@@ -85,10 +85,12 @@ py::dict py_scluster(const Matrix &smw,
                void *weights = (void *)nullptr,
                std::string wfmt="f")
 {
+    use_float = true;
     assert(beta > 0.);
     py::dict retdict;
     py::object asns = py::none(), costs = py::none();
-    std::vector<blz::CompressedVector<float, blz::rowVector>> dvecs = obj2dvec(centers);
+    std::vector<blz::CompressedVector<float, blz::rowVector>> dvecs;
+    smw.perform([&](auto &mat) {dvecs = obj2dvec(centers, mat);});
     const int k = dvecs.size();
     std::vector<Py_ssize_t> shape{Py_ssize_t(smw.rows()), k};
     assert(k >= 1);
@@ -101,23 +103,24 @@ py::dict py_scluster(const Matrix &smw,
         costs = mmfn(py::str(cpath), shape, dt);
         asns = mmfn(py::str(apath), shape, dt);
     } else {
-        if(use_float) costs = py::array_t<float>({smw.rows(), smw.columns()}), asns = py::array_t<float>({smw.rows(), smw.columns()});
-        else costs = py::array_t<double>({smw.rows(), smw.columns()}), asns = py::array_t<double>({smw.rows(), smw.columns()});
+        costs = py::array_t<float>({smw.rows(), smw.columns()}), asns = py::array_t<float>({smw.rows(), smw.columns()});
+        //else costs = py::array_t<double>({smw.rows(), smw.columns()}), asns = py::array_t<double>({smw.rows(), smw.columns()});
     }
     void *cp = py::cast<py::array>(costs).request().ptr,
          *ap = py::cast<py::array>(asns).request().ptr;
-    fprintf(stderr, "cp: %p. ap: %p\n", (void *)cp, (void *)ap);
+#if 0
     if(use_float) {
-        fprintf(stderr, "About to perform soft clustering with floats\n");
-        blz::CustomMatrix<float, unaligned, unpadded, rowMajor> cm((float *)cp, smw.rows(), k);
-        blz::CustomMatrix<float, unaligned, unpadded, rowMajor> am((float *)ap, smw.rows(), k);
-        smw.perform([&](auto &x) {retdict = cpp_scluster(x, k, beta, measure, dvecs, cm, am, temp, kmeansmaxiter, mbsize, mbn, weights, wfmt[0]);});
+#endif
+    blz::CustomMatrix<float, unaligned, unpadded, rowMajor> cm((float *)cp, smw.rows(), k);
+    blz::CustomMatrix<float, unaligned, unpadded, rowMajor> am((float *)ap, smw.rows(), k);
+    smw.perform([&](auto &x) {retdict = cpp_scluster(x, k, beta, measure, dvecs, cm, am, temp, kmeansmaxiter, mbsize, mbn, weights, wfmt[0]);});
+#if 0
     } else {
-        fprintf(stderr, "About to perform soft clustering with doubles\n");
         blz::CustomMatrix<double, unaligned, unpadded, rowMajor> cm((double *)cp, smw.rows(), k);
         blz::CustomMatrix<double, unaligned, unpadded, rowMajor> am((double *)ap, smw.rows(), k);
         smw.perform([&](auto &x) {retdict = cpp_scluster(x, k, beta, measure, dvecs, cm, am, temp, kmeansmaxiter, mbsize, mbn, weights, wfmt[0]);});
     }
+#endif
     retdict["costs"] = costs;
     retdict["asn"] = asns;
     return retdict;

--- a/python/pycmp.cpp
+++ b/python/pycmp.cpp
@@ -116,7 +116,7 @@ void init_cmp(py::module &m) {
                             blz::row(rhr, rhid, unchecked), \
                             blz::row(lhr, lhid, unchecked), \
                             priorc, priorsum,\
-                            rrsums[lrid], lrsums[lhid]);\
+                            rrsums[rhid], lrsums[lhid]);\
             });
             DO_GEN
         } else if(lhs.is_double() && rhs.is_double()) {

--- a/python/pycmp.cpp
+++ b/python/pycmp.cpp
@@ -50,7 +50,7 @@ void init_cmp(py::module &m) {
             if(nc != Py_ssize_t(lhs.columns()))
                 throw std::invalid_argument("Array must be of the same dimensionality as the matrix");
             std::fprintf(stderr, "Processing matrix of shape %zu/%zu\n", nc, ndr);
-            py::array_t<float> ret(std::vector<Py_ssize_t>{Py_ssize_t(nr), nc});
+            py::array_t<float> ret(std::vector<Py_ssize_t>{Py_ssize_t(nr), ndr});
             blz::CustomMatrix<float, unaligned, unpadded, blz::rowMajor> cm((float *)ret.request().ptr, nr, ndr);
             lhs.perform([&](auto &matrix) {
                 using ET = typename std::decay_t<decltype(matrix)>::ElementType;
@@ -58,7 +58,6 @@ void init_cmp(py::module &m) {
 #define CASE_F(char, type) \
                         case char: {\
                             blaze::CustomMatrix<type, unaligned, unpadded> ocm(static_cast<type *>(inf.ptr), ndr, nc);\
-                            std::cerr << ocm << '\n';\
                             const auto cmsums = blz::evaluate(blz::sum<blz::rowwise>(ocm));\
                             blz::SM<float> sv = ocm;\
                             cm = blz::generate(nr, ndr, [&](auto x, auto y) -> float {\
@@ -163,7 +162,7 @@ void init_cmp(py::module &m) {
             if(nc != Py_ssize_t(lhs.columns()))
                 throw std::invalid_argument("Array must be of the same dimensionality as the matrix");
             std::fprintf(stderr, "Processing matrix of shape %zu/%zu\n", nc, ndr);
-            py::array_t<float> ret(std::vector<Py_ssize_t>{Py_ssize_t(nr), nc});
+            py::array_t<float> ret(std::vector<Py_ssize_t>{Py_ssize_t(nr), ndr});
             blz::CustomMatrix<float, unaligned, unpadded, blz::rowMajor> cm((float *)ret.request().ptr, nr, ndr);
             lhs.perform([&](auto &matrix) {
                 using ET = typename std::decay_t<decltype(matrix)>::ElementType;
@@ -171,7 +170,6 @@ void init_cmp(py::module &m) {
 #define CASE_F(char, type) \
                         case char: {\
                             blaze::CustomMatrix<type, unaligned, unpadded> ocm(static_cast<type *>(inf.ptr), ndr, nc);\
-                            std::cerr << ocm << '\n';\
                             const auto cmsums = blz::evaluate(blz::sum<blz::rowwise>(ocm));\
                             blz::SM<float> sv = ocm;\
                             cm = blz::generate(nr, ndr, [&](auto x, auto y) -> float {\

--- a/python/pycmp.cpp
+++ b/python/pycmp.cpp
@@ -1,12 +1,16 @@
 
 #include "pyfgc.h"
 #include "smw.h"
+#include "pycsparse.h"
 #include "pyhelpers.h"
 using blaze::unaligned;
 using blaze::unpadded;
 using blaze::rowwise;
 using blaze::unchecked;
 
+using minicore::util::sum;
+using minicore::util::row;
+using blaze::row;
 
 void init_cmp(py::module &m) {
     m.def("cmp", [](const SparseMatrixWrapper &lhs, py::array arr, py::object msr, py::object betaprior) {
@@ -120,6 +124,106 @@ void init_cmp(py::module &m) {
                 return cmp::msr_with_prior<float>(ms, blz::row(lhr, lhid, blz::unchecked), blz::row(rhr, rhid, unchecked), priorc, priorsum, lrsums[lhid], rrsums[rhid]);
             });
         }
+        return ret;
+    }, py::arg("matrix"), py::arg("data"), py::arg("msr") = 2, py::arg("prior") = 0.);
+    m.def("cmp", [](const PyCSparseMatrix &lhs, py::array arr, py::object msr, py::object betaprior) {
+        auto inf = arr.request();
+        const double priorv = betaprior.cast<double>(), priorsum = priorv * lhs.columns();
+        if(inf.format.size() != 1) throw std::invalid_argument("Invalid dtype");
+        const char dt = inf.format[0];
+        const size_t nr = lhs.rows();
+        const auto ms = assure_dm(msr);
+        blz::DV<float> rsums(lhs.rows());
+        blz::DV<double> priorc({priorv});
+        lhs.perform([&](const auto &x){rsums = sum<rowwise>(x);});
+        if(inf.ndim == 1) {
+            if(inf.size != Py_ssize_t(lhs.columns())) throw std::invalid_argument("Array must be of the same dimensionality as the matrix");
+            py::array_t<float> ret(nr);
+            auto v = blz::make_cv((float *)ret.request().ptr, nr);
+            lhs.perform([&](auto &matrix) {
+                using ET = typename std::decay_t<decltype(matrix)>::ElementType;
+                using MsrType = std::conditional_t<std::is_floating_point_v<ET>, ET, std::conditional_t<(sizeof(ET) <= 4), float, double>>;
+                switch(dt) {
+#define CASE_F(char, type) \
+                    case char: {\
+                        blz::SV<float> sv(blz::make_cv((type *)inf.ptr, inf.size));\
+                        const auto vsum = blz::sum(sv);\
+                        v = blz::generate(nr, [vsum,priorsum,ms,&matrix,&rsums,&sv,&priorc](auto x) {return cmp::msr_with_prior<MsrType>(ms, row(matrix, x), sv, priorc, priorsum, rsums[x], vsum);});\
+                    } break;
+                    CASE_F('f', float)
+                    CASE_F('d', double)
+                    case 'i': CASE_F('I', unsigned)
+#undef CASE_F
+                    default: throw std::invalid_argument("dtypes supported: d, f, i, I");
+                }
+            });
+            return ret;
+        } else if(inf.ndim == 2) {
+            const Py_ssize_t nc = inf.shape[1], ndr = inf.shape[0];
+            if(nc != Py_ssize_t(lhs.columns()))
+                throw std::invalid_argument("Array must be of the same dimensionality as the matrix");
+            std::fprintf(stderr, "Processing matrix of shape %zu/%zu\n", nc, ndr);
+            py::array_t<float> ret(std::vector<Py_ssize_t>{Py_ssize_t(nr), nc});
+            blz::CustomMatrix<float, unaligned, unpadded, blz::rowMajor> cm((float *)ret.request().ptr, nr, ndr);
+            lhs.perform([&](auto &matrix) {
+                using ET = typename std::decay_t<decltype(matrix)>::ElementType;
+                using MsrType = std::conditional_t<std::is_floating_point_v<ET>, ET, std::conditional_t<(sizeof(ET) <= 4), float, double>>;
+#define CASE_F(char, type) \
+                        case char: {\
+                            blaze::CustomMatrix<type, unaligned, unpadded> ocm(static_cast<type *>(inf.ptr), ndr, nc);\
+                            std::cerr << ocm << '\n';\
+                            const auto cmsums = blz::evaluate(blz::sum<blz::rowwise>(ocm));\
+                            blz::SM<float> sv = ocm;\
+                            cm = blz::generate(nr, ndr, [&](auto x, auto y) -> float {\
+                                return cmp::msr_with_prior<MsrType>(ms, row(matrix, x, unchecked), row(sv, y, unchecked), priorc, priorsum, rsums[x], cmsums[y]);\
+                            });\
+                        } break;
+                    switch(dt) {
+                        CASE_F('f', float)
+                        CASE_F('d', double)
+                        CASE_F('i', int)
+                        CASE_F('I', unsigned)
+                        CASE_F('h', int16_t)
+                        CASE_F('H', uint16_t)
+                        CASE_F('b', int16_t)
+                        CASE_F('B', uint16_t)
+                        CASE_F('l', int64_t)
+                        CASE_F('L', uint64_t)
+#undef CASE_F
+                        default: throw std::invalid_argument("dtypes supported: d, f, i, I, h, H, b, B, l, L");
+                    }
+                    return 0.;
+            });
+            return ret;
+        } else {
+            throw std::invalid_argument("NumPy array expected to have 1 or two dimensions.");
+        }
+        __builtin_unreachable();
+        return py::array_t<float>();
+    }, py::arg("matrix"), py::arg("data"), py::arg("msr") = 2, py::arg("prior") = 0.);
+    m.def("cmp", [](const PyCSparseMatrix &lhs, const PyCSparseMatrix &rhs, py::object msr, py::object betaprior) {
+        if(lhs.data_t_ != rhs.data_t_ || lhs.indices_t_ != rhs.indices_t_ || lhs.indptr_t_ != rhs.indptr_t_) {
+            std::string lmsg = std::string("lhs ") + lhs.data_t_ + "," + lhs.indices_t_ + "," + lhs.indptr_t_;
+            std::string rmsg = std::string("rhs ") + rhs.data_t_ + "," + rhs.indices_t_ + "," + rhs.indptr_t_;
+            throw std::invalid_argument(std::string("mismatched types: ") + lmsg + rmsg);
+        }
+        const double priorv = betaprior.cast<double>(), priorsum = priorv * lhs.columns();
+        const auto ms = assure_dm(msr);
+        blz::DV<float> lrsums(lhs.rows());
+        blz::DV<float> rrsums(lhs.rows());
+        blz::DV<double> priorc({priorv});
+        if(lhs.columns() != rhs.columns()) throw std::invalid_argument("mismatched # columns");
+        lhs.perform([&](const auto &x){lrsums = sum<rowwise>(x);});
+        rhs.perform([&](const auto &x){rrsums = sum<rowwise>(x);});
+        const Py_ssize_t nr = lhs.rows(), nc = rhs.rows();
+        py::array ret(py::dtype("f"), std::vector<Py_ssize_t>{nr, nc});
+        auto retinf = ret.request();
+        blz::CustomMatrix<float, unaligned, unpadded, blz::rowMajor> cm((float *)retinf.ptr, nr, nc, nc);
+        lhs.perform(rhs, [&](auto &mat, auto &rmat) {
+            cm = blz::generate(nr, nc, [&](auto lhid, auto rhid) -> float {
+                return cmp::msr_with_prior<float>(ms, row(mat, lhid), row(rmat, rhid), priorc, priorsum, lrsums[lhid], rrsums[rhid]);
+            });
+        });
         return ret;
     }, py::arg("matrix"), py::arg("data"), py::arg("msr") = 2, py::arg("prior") = 0.);
 }

--- a/python/pycsparse.cpp
+++ b/python/pycsparse.cpp
@@ -100,7 +100,7 @@ void init_pycsparse(py::module &m) {
     m.def("kmeanspp",  run_kmpp_noso,
        "Computes a selecion of points from the matrix pointed to by smw, returning indexes for selected centers, along with assignments and costs for each point."
        "\nSet nkmc to -1 to perform streaming kmeans++ (kmc2 over the full dataset), which parallelizes better but may yield a lower-quality result.\n",
-       py::arg("smw"), py::arg("msr"), py::arg("k"), py::arg("betaprior") = 0., py::arg("seed") = 0, py::arg("nkmc") = 0, py::arg("ntimes") = 1,
+       py::arg("smw"), py::arg("msr"), py::arg("k"), py::arg("prior") = 0., py::arg("seed") = 0, py::arg("nkmc") = 0, py::arg("ntimes") = 1,
        py::arg("lspp") = 0, py::arg("use_exponential_skips") = false,
        py::arg("weights") = py::none()
     );

--- a/python/pyhelpers.h
+++ b/python/pyhelpers.h
@@ -77,26 +77,36 @@ auto vec2fnp(const T &x) {
 }
 
 
-inline std::vector<blz::CompressedVector<float, blz::rowVector>> obj2dvec(py::object x) {
+template<typename Mat>
+inline std::vector<blz::CompressedVector<float, blz::rowVector>> obj2dvec(py::object x, const Mat &mat) {
     std::vector<blz::CompressedVector<float, blz::rowVector>> dvecs;
-    if(py::isinstance<py::array>(x)) {
+    if(py::isinstance<py::array>(x) && py::cast<py::array>(x).request().ndim == 2) {
         auto cbuf = py::cast<py::array>(x).request();
         set_centers(&dvecs, cbuf);
-    } else if(py::isinstance<py::list>(x)) {
-        for(auto item: x) {
-            auto ca = py::cast<py::array>(item);
-            auto bi = ca.request();
-            const auto fmt = bi.format[0];
-            auto emp = [&](auto &x) {
-                dvecs.emplace_back();
-                dvecs.back() = trans(x);
-            };
-            if(fmt == 'd') {
-                auto cv = blz::make_cv((double *)bi.ptr, bi.size);
-                emp(cv);
-            } else {
-                auto cv = blz::make_cv((float *)bi.ptr, bi.size);
-                emp(cv);
+    } else if(py::isinstance<py::sequence>(x)) {
+        if(py::isinstance<py::int_>(py::cast<py::sequence>(x)[0])) {
+            const size_t nc = mat.columns();
+            for(auto item: py::cast<py::sequence>(x)) {
+                Py_ssize_t rownum = py::cast<py::int_>(item).cast<Py_ssize_t>();
+                auto &v = dvecs.emplace_back();
+                v.resize(nc);
+                auto r = row(mat, rownum);
+                v.reserve(nonZeros(r));
+                if constexpr(blaze::IsDenseMatrix_v<Mat>) {
+                    for(size_t i = 0; i < nc; ++i) {
+                        if(r[i] > 0.) v.append(i, r[i]);
+                    }
+                } else {
+                    for(const auto &pair: r) v.append(pair.index(), pair.value());
+                }
+            }
+        } else {
+            for(auto item: py::cast<py::sequence>(x)) {
+                auto ca = py::cast<py::array>(item);
+                auto bi = ca.request();
+                auto emp = [&](const auto &x) {dvecs.emplace_back() = trans(x);};
+                if(bi.format[0] == 'd') emp(blz::make_cv((double *)bi.ptr, bi.size));
+                else                    emp(blz::make_cv((float *)bi.ptr, bi.size));
             }
         }
     } else throw std::invalid_argument("centers must be a numpy array or list of numpy arrays");

--- a/python/pyhelpers.h
+++ b/python/pyhelpers.h
@@ -84,7 +84,18 @@ inline std::vector<blz::CompressedVector<float, blz::rowVector>> obj2dvec(py::ob
         auto cbuf = py::cast<py::array>(x).request();
         set_centers(&dvecs, cbuf);
     } else if(py::isinstance<py::sequence>(x)) {
-        if(py::isinstance<py::int_>(py::cast<py::sequence>(x)[0])) {
+        auto seq = py::cast<py::sequence>(x);
+        auto fi = seq[0];
+        if(py::isinstance<py::array>(fi)) {
+            for(auto item: py::cast<py::sequence>(x)) {
+                auto ca = py::cast<py::array>(item);
+                auto bi = ca.request();
+                auto emp = [&](const auto &x) {dvecs.emplace_back() = trans(x);};
+                if(bi.format[0] == 'd') emp(blz::make_cv((double *)bi.ptr, bi.size));
+                else if(bi.format[0] == 'f') emp(blz::make_cv((float *)bi.ptr, bi.size));
+                else throw std::invalid_argument("Array type must be float or double");
+            }
+        } else if(py::isinstance<py::int_>(fi)) {
             const size_t nc = mat.columns();
             for(auto item: py::cast<py::sequence>(x)) {
                 Py_ssize_t rownum = py::cast<py::int_>(item).cast<Py_ssize_t>();
@@ -96,20 +107,10 @@ inline std::vector<blz::CompressedVector<float, blz::rowVector>> obj2dvec(py::ob
                     for(size_t i = 0; i < nc; ++i) {
                         if(r[i] > 0.) v.append(i, r[i]);
                     }
-                } else {
-                    for(const auto &pair: r) v.append(pair.index(), pair.value());
-                }
+                } else for(const auto &pair: r) v.append(pair.index(), pair.value());
             }
-        } else {
-            for(auto item: py::cast<py::sequence>(x)) {
-                auto ca = py::cast<py::array>(item);
-                auto bi = ca.request();
-                auto emp = [&](const auto &x) {dvecs.emplace_back() = trans(x);};
-                if(bi.format[0] == 'd') emp(blz::make_cv((double *)bi.ptr, bi.size));
-                else                    emp(blz::make_cv((float *)bi.ptr, bi.size));
-            }
-        }
-    } else throw std::invalid_argument("centers must be a numpy array or list of numpy arrays");
+        } else throw std::invalid_argument("Invalid: expected numpy array or list of numpy arrays or list of center ids");
+    } else throw std::invalid_argument("centers must be a 2d numpy array or sequence containing numpy arrays of the full vectors or center ids");
     return dvecs;
 }
 inline std::string size2dtype(Py_ssize_t n) {

--- a/python/pyomp.cpp
+++ b/python/pyomp.cpp
@@ -2,7 +2,7 @@
 
 
 py::ssize_t threadgetter() {
-    py::ssize_t ret;
+    py::ssize_t ret = 1;
 #ifdef _OPENMP
     #pragma omp parallel
     {

--- a/python/pyomp.cpp
+++ b/python/pyomp.cpp
@@ -2,12 +2,17 @@
 
 
 py::ssize_t threadgetter() {
-    py::ssize_t ret = 1;
-    OMP_ONLY(ret = omp_get_num_threads();)
+    py::ssize_t ret;
+#ifdef _OPENMP
+    #pragma omp parallel
+    {
+        ret = omp_get_num_threads();
+    }
+#endif
     return ret;
 }
 void threadsetter(py::ssize_t x) {
-    OMP_ONLY(if(x > 0) omp_set_num_threads(x);)
+    if(x > 0) omp_set_num_threads(x);
 }
 struct OMPThreadNumManager {
     OMPThreadNumManager(int nthreads=-1) {set(nthreads);}

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,6 @@ def parallelCCompile(self, sources, output_dir=None, macros=None,
 import distutils.ccompiler
 distutils.ccompiler.CCompiler.compile=parallelCCompile
 
-__version__ = check_output(["git", "describe", "--abbrev=4"]).decode().strip().split("-")[0]
 
 
 
@@ -175,6 +174,8 @@ class BuildExt(build_ext):
             ext.extra_link_args = link_opts + extra_link_opts
         build_ext.build_extensions(self)
 
+
+__version__ = "0.2.2"
 setup(
     name='minicore',
     version=__version__,
@@ -184,8 +185,8 @@ setup(
     description='A python module for coresets and clustering',
     long_description='',
     ext_modules=ext_modules,
-    install_requires=['pybind11>=2.4', 'numpy>=0.19'],
-    setup_requires=['pybind11>=2.4'],
+    install_requires=['pybind11', 'numpy>=0.19'],
+    setup_requires=['pybind11'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
     packages=find_packages()

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,6 @@ import sys
 from os import environ, path, makedirs
 from setuptools.command.build_ext import build_ext
 from glob import glob
-from subprocess import check_output, check_call
 import multiprocessing
 import multiprocessing.pool
 
@@ -12,6 +11,7 @@ sleefdir = environ.get("SLEEF_DIR", "../sleef/build")
 SLEEFLIB = sleefdir + "/lib/libsleef.a"
 
 if not path.isfile(SLEEFLIB):
+    from subprocess import check_call
     if not path.isdir(sleefdir):
         makedirs(sleefdir)
     check_call(f"cd {sleefdir} && cmake .. -DBUILD_SHARED_LIBS=0 && make", shell=True)

--- a/src/mtx2cs.cpp
+++ b/src/mtx2cs.cpp
@@ -292,9 +292,8 @@ int m2ccore(std::string in, std::string out, SumOpts &opts)
             }
             break;
         }
-        case dist::L2: case dist::PL2: {
+        case dist::L2: {
             assert(min(sm) >= 0.);
-            if(opts.dis == dist::PL2) for(auto r: blz::rowiterator(sm)) r /= blz::sum(r);
             if(opts.soft) {
                 throw NotImplementedError("L2/PL2 under soft clustering");
             } else {
@@ -392,8 +391,6 @@ int main(int argc, char **argv) {
             case 'I': opts.dis = dist::REVERSE_ITAKURA_SAITO; break;
             case 'J': opts.dis = dist::JSM;       break;
             case 'M': opts.dis = dist::MKL;       break;
-            case 'P': opts.dis = dist::PSL2;      break;
-            case 'Q': opts.dis = dist::PL2;       break;
             case 'S': opts.dis = dist::SQRL2;     break;
             case 'T': opts.dis = dist::TVD;       break;
             case 'Y': opts.dis = dist::BHATTACHARYYA_DISTANCE; break;

--- a/src/tests/solvetest.cpp
+++ b/src/tests/solvetest.cpp
@@ -191,5 +191,6 @@ int main(int argc, char *argv[]) {
     std::fprintf(stderr, "minibatch clustering with uniform weights, %sreplacement, %s importance sampling\n", with_replacement ? "with": "without", "without");
     clust::perform_hard_minibatch_clustering(x, msr, prior, is_mbcenters, asn, hardcosts, &weights, mbsize, NUMITER, 10, /*reseed_after=*/minreseed, /*with_replacement=*/with_replacement, /*seed=*/rng());
     std::fprintf(stderr, "now, using coreset minibatch clustering.\n");
-    //minicore::hmb_coreset_clustering(x, msr, prior, mbcenters, asn, hardcosts, static_cast<blz::DV<FLOAT_TYPE> *>(nullptr), mbsize, NUMITER, 10, minreseed, with_replacement, rng());
+    auto cs_mbcenters = ocenters;
+    minicore::hmb_coreset_clustering(x, msr, prior, cs_mbcenters, asn, hardcosts, static_cast<blz::DV<FLOAT_TYPE> *>(nullptr), mbsize, NUMITER, 10, minreseed, with_replacement, rng());
 }

--- a/src/tests/solvetest.cpp
+++ b/src/tests/solvetest.cpp
@@ -190,4 +190,6 @@ int main(int argc, char *argv[]) {
     auto is_mbcenters = ocenters;
     std::fprintf(stderr, "minibatch clustering with uniform weights, %sreplacement, %s importance sampling\n", with_replacement ? "with": "without", "without");
     clust::perform_hard_minibatch_clustering(x, msr, prior, is_mbcenters, asn, hardcosts, &weights, mbsize, NUMITER, 10, /*reseed_after=*/minreseed, /*with_replacement=*/with_replacement, /*seed=*/rng());
+    std::fprintf(stderr, "now, using coreset minibatch clustering.\n");
+    //minicore::hmb_coreset_clustering(x, msr, prior, mbcenters, asn, hardcosts, static_cast<blz::DV<FLOAT_TYPE> *>(nullptr), mbsize, NUMITER, 10, minreseed, with_replacement, rng());
 }


### PR DESCRIPTION
1. Use normalized means for mean-based measures
2. Add `reverse=` arguments to `minicore.cmp`
3. Add cmp functionality for comparing CSparseMatrix objects of the same kind.
4. Move ls++ matrix to disk if > 16GB by default.
5. Add use_cs option for hard clustering, which uses coreset optimization in place of minibatch k-means.