### PR TITLE
Better Python Support/Docs

### DIFF
--- a/include/minicore/dist/applicator.h
+++ b/include/minicore/dist/applicator.h
@@ -1621,6 +1621,14 @@ auto make_d2_coreset_sampler(const DissimilarityApplicator<MatrixType> &app, uns
     return cs;
 }
 
+template<typename T>
+static constexpr inline double getv(const T &x) {
+    if constexpr(std::is_arithmetic_v<T>) {return double(x);}
+    else {
+        return x[0];
+    }
+}
+
 template<typename FT=float, typename CtrT, typename MatrixRowT, typename PriorT, typename PriorSumT, typename SumT, typename OSumT>
 double msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixRowT &mr, const PriorT &prior, PriorSumT prior_sum, SumT ctrsum, OSumT mrsum)
 {
@@ -1637,7 +1645,7 @@ double msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const Mat
 #define SMALLEST_PRIOR 7.0069e-42f
 #endif
     FT smallest_pv = FT(SMALLEST_PRIOR) * (lhsum + rhsum);
-    const FT pv = std::max(FT(prior[0]), smallest_pv);
+    const FT pv = std::max(FT(getv(prior)), smallest_pv);
     prior_sum = pv * nd;
     lhsum = mrsum + prior_sum;
     rhsum = ctrsum + prior_sum;

--- a/include/minicore/dist/distance.h
+++ b/include/minicore/dist/distance.h
@@ -531,8 +531,8 @@ INLINE auto multinomial_jsd(const blaze::DenseVector<VT, SO> &lhs,
                             const blaze::DenseVector<VT, SO> &rhs)
 {
     using RT = blz::ElementType_t<VT>;
-    auto lhlog = blaze::evaluate(neginf2zero(log(lhs)));
-    auto rhlog = blaze::evaluate(neginf2zero(log(rhs)));
+    auto lhlog = blaze::evaluate(neginf2zero(log(*lhs)));
+    auto rhlog = blaze::evaluate(neginf2zero(log(*rhs)));
     auto mnlog = blaze::evaluate(neginf2zero(log((*lhs + *rhs) * RT(0.5))));
     auto lhc = blaze::dot(*lhs, *lhlog - mnlog);
     auto rhc = blaze::dot(*rhs, *rhlog - mnlog);
@@ -555,7 +555,7 @@ INLINE auto multinomial_jsd(const blaze::SparseVector<VT, SO> &lhs,
                             const blaze::SparseVector<VT, SO> &rhs)
 {
     using RT = blz::ElementType_t<VT>;
-    auto lhlog = blaze::log(lhs), rhlog = blaze::log(rhs);
+    auto lhlog = blaze::log(lhs), rhlog = blaze::log(*rhs);
     auto mnlog = blaze::evaluate(blaze::log((*lhs + *rhs) * RT(0.5)));
     auto lhc = blaze::dot(*lhs, *lhlog - mnlog);
     auto rhc = blaze::dot(*rhs, *rhlog - mnlog);
@@ -568,9 +568,9 @@ INLINE auto multinomial_bregman(const blaze::DenseVector<FT, SO> &lhs,
                                 const blaze::DenseVector<FT, SO> &lhlog,
                                 const blaze::DenseVector<FT, SO> &rhlog)
 {
-    assert_all_nonzero(lhs);
-    assert_all_nonzero(rhs);
-    return blaze::dot(lhs, lhlog - rhlog);
+    assert_all_nonzero(*lhs);
+    assert_all_nonzero(*rhs);
+    return blaze::dot(*lhs, *lhlog - *rhlog);
 }
 template<typename FT, bool SO>
 INLINE auto      poisson_bregman(const blaze::DenseVector<FT, SO> &lhs,
@@ -579,9 +579,9 @@ INLINE auto      poisson_bregman(const blaze::DenseVector<FT, SO> &lhs,
                                  const blaze::DenseVector<FT, SO> &rhlog)
 {
     // Assuming these are all independent (not ideal)
-    assert_all_nonzero(lhs);
-    assert_all_nonzero(rhs);
-    return blaze::dot(lhs, lhlog - rhlog) + blaze::sum(rhs - lhs);
+    assert_all_nonzero(*lhs);
+    assert_all_nonzero(*rhs);
+    return blaze::dot(*lhs, *lhlog - *rhlog) + blaze::sum(*rhs - *lhs);
 }
 } // namespace bnj
 using namespace bnj;
@@ -637,7 +637,7 @@ auto bhattacharyya_measure(const blz::DenseVector<VT1, TF> &lhs, const blz::Dens
     // Requires same storage.
     // TODO: generalize for different storage classes/transpose flags using DenseVector and SparseVector
     // base classes
-    return sum(sqrt(*lhs * *rhs));
+    return sum(sqrt(lhs * rhs));
 }
 
 template<typename LHVec, typename RHVec>
@@ -670,14 +670,13 @@ INLINE decltype(auto) multinomial_jsm(Args &&...args) {
 template<typename VT, typename VT2, bool SO>
 inline auto s2jsd(const blz::Vector<VT, SO> &lhs, const blaze::Vector<VT2, SO> &rhs) {
     // Approximate jsd function for use in LSH tables.
-    return std::sqrt(blz::sum(blz::pow(*lhs - *rhs, 2) / (*lhs + *rhs)) * ElementType_t<VT>(0.5));
+    return std::sqrt(blz::sum(blz::pow(lhs - rhs, 2) / (lhs + rhs)) * ElementType_t<VT>(0.5));
 }
 
 
 template<typename VT, bool SO, typename VT2, typename CT=CommonType_t<ElementType_t<VT>, ElementType_t<VT2>>>
 CT scipy_p_wasserstein(const blz::SparseVector<VT, SO> &x, const blz::SparseVector<VT2, SO> &y, double p=1.) {
-    auto &xr = *x;
-    auto &yr = *y;
+    auto &xr = *x; auto &yr = *y;
     const size_t sz = xr.size();
     std::unique_ptr<uint32_t[]> ptr(new uint32_t[sz * 2]);
     auto xptr = ptr.get(), yptr = ptr.get() + sz;
@@ -774,7 +773,7 @@ CT scipy_p_wasserstein(const blz::Vector<VT, SO> &x, const blz::Vector<VT2, SO> 
 
 template<typename VT, bool SO, typename VT2, typename CT=CommonType_t<ElementType_t<VT>, ElementType_t<VT2>>>
 CT p_wasserstein(const blz::Vector<VT, SO> &x, const blz::Vector<VT2, SO> &y, double p=1.) {
-    return scipy_p_wasserstein(x, y, p);
+    return scipy_p_wasserstein(*x, *y, p);
 }
 
 template<typename VT, bool SO, typename VT2>
@@ -800,9 +799,9 @@ static INLINE auto canberra_distance(const blz::DenseVector<VT, SO> &lhs, const 
 template<typename VT, typename VT2, bool SO, bool SO2>
 static INLINE auto hellinger(const blz::Vector<VT, SO> &lhs, const blz::Vector<VT2, SO2> &rhs) {
     if constexpr(SO == SO2) {
-        return l2Norm(sqrt(*lhs) - sqrt(*rhs));
+        return l2Norm(sqrt(lhs) - sqrt(rhs));
     } else {
-        return l2Norm(sqrt(*lhs) - trans(sqrt(*rhs)));
+        return l2Norm(sqrt(lhs) - trans(sqrt(rhs)));
     }
 }
 

--- a/include/minicore/util/Inf2Zero.h
+++ b/include/minicore/util/Inf2Zero.h
@@ -229,7 +229,7 @@ inline decltype(auto) neginf2zero( const DenseVector<VT,TF>& dv )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( *dv, NegInf2Zero() );
+   return map( ~dv, NegInf2Zero() );
 }
 
 template< typename VT  // Type of the sparse vector
@@ -238,7 +238,7 @@ inline decltype(auto) neginf2zero( const SparseVector<VT,TF>& sv )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return *sv;
+   return ~sv;
 }
 
 template< typename MT  // Type of the sparse matrix
@@ -247,7 +247,7 @@ inline decltype(auto) neginf2zero( const SparseMatrix<MT,TF>& sm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return *sm;
+   return ~sm;
 }
 
 template< typename MT  // Type of the sparse matrix
@@ -256,7 +256,7 @@ inline decltype(auto) neginf2zero( const DenseMatrix<MT,TF>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( *dm, NegInf2Zero() );
+   return map( ~dm, NegInf2Zero() );
 }
 
 

--- a/include/minicore/util/blaze_adaptor.h
+++ b/include/minicore/util/blaze_adaptor.h
@@ -19,6 +19,14 @@ namespace blz {
 template<blaze::AlignmentFlag AF = blaze::unaligned, blaze::PaddingFlag PF=blaze::unpadded, typename FT, typename IT>
 auto make_cv(FT *data, IT size);
 
+#if 0
+template<typename MT, bool SO> decltype(auto) operator*(const blaze::Matrix<MT, SO> &x) {return ~x;}
+template<typename VT, bool SO> decltype(auto) operator*(const blaze::Vector<VT, SO> &x) {return ~x;}
+template<typename MT, bool SO> decltype(auto) operator*(blaze::Matrix<MT, SO> &x) {return ~x;}
+template<typename VT, bool SO> decltype(auto) operator*(blaze::Vector<VT, SO> &x) {return ~x;}
+#endif
+    
+
 // These blaze adaptors exist for the purpose of
 // providing a pair of iterators.
 template<typename this_type>
@@ -297,7 +305,10 @@ template<typename OT>
 INLINE decltype(auto) sum(const OT &x) {return blaze::sum(x);}
 
 template<bool wiseness, typename OT>
-INLINE decltype(auto) sum(const OT &x) {return blaze::sum<wiseness>(x);}
+INLINE decltype(auto) sum(const OT &x) {
+    //std::fprintf(stderr, "[%s:%s:%d] Computing %d-wise sum\n", __PRETTY_FUNCTION__, __FILE__, __LINE__, wiseness);
+    return blaze::sum<wiseness>(x);
+}
 
 template<typename OT>
 INLINE decltype(auto) max(const OT &x) {return blaze::max(x);}

--- a/minicore/__init__.py
+++ b/minicore/__init__.py
@@ -47,8 +47,6 @@ def kmeanspp(matrix, k, *, msr=2, prior=0., seed=0, ntimes=1, lspp=0, expskips=0
         matrix = CSparseMatrix(matrix)
     if isinstance(k, SumOpts):
         return pykmpp(matrix, k, weights=weights)
-    if hasattr(matrix, "dtype"):
-        print("About to call kmeanspp, matrix = %s, %s" % (matrix, matrix.dtype))
     return pykmpp(matrix, k=k, msr=msr, prior=prior, seed=seed, ntimes=ntimes,
                                lspp=lspp, expskips=expskips,
                                n_local_trials=n_local_trials,

--- a/minicore/__init__.py
+++ b/minicore/__init__.py
@@ -1,5 +1,6 @@
 from pyminicore import kmeanspp as pykmpp
-from pyminicore import SumOpts, CSparseMatrix
+from pyminicore import SumOpts, CSparseMatrix, CoresetSampler
+from pyminicore import pcmp, cmp
 from pyminicore import SparseMatrixWrapper as smw
 import pyminicore
 from .util import constants
@@ -52,6 +53,21 @@ def kmeanspp(matrix, k, *, msr=2, prior=0., seed=0, ntimes=1, lspp=0, expskips=0
                                lspp=lspp, expskips=expskips,
                                n_local_trials=n_local_trials,
                                weights=weights)
+
+'''
+def cmp(x, y=None, *, msr=2, prior=0., reverse=False, use_float=True):
+    """
+    Performs distance calculations between x and y
+    If y is None, performs pairwise comparisons against itself.
+    """
+    if y is None:
+        return pyminicore.pcmp(x, msr=msr, prior=prior, use_float=use_foat)
+    if isinstance(x, sp.csr_matrix):
+        x = mc.CSparseMatrix(x)
+    if isinstance(y, sp.csr_matrix):
+        y = mc.CSparseMatrix(y)
+    return pyminicore.cmp(x, y, msr=msr, prior=prior, reverse=
+'''
 
 
 def hcluster(matrix, centers, *, prior=0., msr=2, weights=None,
@@ -221,6 +237,9 @@ def cluster(data, *, msr, k, prior=0., seed=0, nmkc=0,
             n_local_trials=1, weights=None, mbsize=-1, clustereps=1e-4,
             temp=-1., cs=False, with_rep=True, outpref="mc.cluster.output",
             maxiter=50):
+    """Convenience wrapper for hcluster and scluster which selects
+        either hard or soft clustering
+    """
     soft = temp > 0.  # Enable soft clustering by setting temperature
     if isinstance(data, csr_tuple):
         mcdata = CSparseMatrix(data)

--- a/python/examples/coreset_example.py
+++ b/python/examples/coreset_example.py
@@ -1,0 +1,19 @@
+from numpy import random, ascontiguousarray
+import minicore as mc
+from sklearn.datasets import make_blobs
+import numpy as np
+
+dat = np.random.rand(10000).reshape(1000, 10)
+
+res = mc.kmeanspp(dat, k=25, msr=2)
+out, asn, costs  = res
+
+cs = mc.CoresetSampler()
+
+sensid = mc.constants.SENSDICT["LBK"] # This uses coresets for Bregman divergences
+
+cs.make_sampler(25, costs=costs, assignments=asn, sens=4)
+
+weights, ids = cs.sample(100)
+top = sorted(zip(ids, weights), key=lambda x: -x[1])[:10]
+print("top 10: ", top)

--- a/python/pycentroid.cpp
+++ b/python/pycentroid.cpp
@@ -6,7 +6,7 @@ template<typename FT>
 auto pygeomedian(py::array_t<FT, py::array::c_style | py::array::forcecast> data, py::object weights, FT eps) {
     auto dbuf = data.request();
     if(dbuf.ndim != 2) throw std::runtime_error("Expected 2-d array");
-    Py_ssize_t ndret = dbuf.shape[1];
+    py::ssize_t ndret = dbuf.shape[1];
     py::array_t<FT> ret(ndret);
     auto rbuf = ret.request();
     FT *retp = (FT *)rbuf.ptr;

--- a/python/pycluster.cpp
+++ b/python/pycluster.cpp
@@ -5,8 +5,8 @@ void init_clustering(py::module &m) {
 
     m.def("hcluster", [](SparseMatrixWrapper &smw, py::object centers, double beta,
                          py::object msr, py::object weights, double eps,
-                         uint64_t kmeansmaxiter, uint64_t seed, Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                         Py_ssize_t reseed_count, bool with_rep, bool use_cs) {
+                         uint64_t kmeansmaxiter, uint64_t seed, py::ssize_t mbsize, py::ssize_t ncheckins,
+                         py::ssize_t reseed_count, bool with_rep, bool use_cs) {
                              return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
                                  seed,
                                  mbsize, ncheckins, reseed_count, with_rep, use_cs);
@@ -19,9 +19,9 @@ void init_clustering(py::module &m) {
     py::arg("eps") = 1e-10,
     py::arg("maxiter") = 100,
     py::arg("seed") = 0,
-    py::arg("mbsize") = Py_ssize_t(-1),
-    py::arg("ncheckins") = Py_ssize_t(-1),
-    py::arg("reseed_count") = Py_ssize_t(5),
+    py::arg("mbsize") = py::ssize_t(-1),
+    py::arg("ncheckins") = py::ssize_t(-1),
+    py::arg("reseed_count") = py::ssize_t(5),
     py::arg("with_rep") = false, py::arg("cs") = false,
     "Clusters a SparseMatrixWrapper object using settings and the centers provided above; set prior to < 0 for it to be 1 / ncolumns(). Performs seeding, followed by EM or minibatch k-means");
 } // init_clustering

--- a/python/pycluster.h
+++ b/python/pycluster.h
@@ -15,11 +15,11 @@ py::dict cpp_pycluster_from_centers(const Matrix &mat, unsigned int k, double be
                WFT *weights,
                double eps,
                size_t kmeansmaxiter,
-               Py_ssize_t mbsize,
-               Py_ssize_t ncheckins,
-               Py_ssize_t reseed_count,
+               py::ssize_t mbsize,
+               py::ssize_t ncheckins,
+               py::ssize_t reseed_count,
                bool with_rep,
-               Py_ssize_t seed,
+               py::ssize_t seed,
                bool use_cs=false)
 {
     if(k != ctrs.size()) {
@@ -32,7 +32,7 @@ py::dict cpp_pycluster_from_centers(const Matrix &mat, unsigned int k, double be
         clusterret = perform_hard_clustering(mat, measure, prior, ctrs, asn, costs, weights, eps, kmeansmaxiter);
     } else {
         if(ncheckins < 0) ncheckins = 10;
-        Py_ssize_t checkin_freq = (kmeansmaxiter + ncheckins - 1) / ncheckins;
+        py::ssize_t checkin_freq = (kmeansmaxiter + ncheckins - 1) / ncheckins;
         if(use_cs) {
             clusterret = hmb_coreset_clustering(mat, measure, prior, ctrs, asn, costs, weights,
                                                 mbsize, kmeansmaxiter, checkin_freq, reseed_count, seed);
@@ -70,11 +70,11 @@ py::dict cpp_pycluster_from_centers_base(const Matrix &mat, unsigned int k, doub
                WFT *weights,
                double eps,
                size_t kmeansmaxiter,
-               Py_ssize_t mbsize,
-               Py_ssize_t ncheckins,
-               Py_ssize_t reseed_count,
+               py::ssize_t mbsize,
+               py::ssize_t ncheckins,
+               py::ssize_t reseed_count,
                bool with_rep,
-               Py_ssize_t seed,
+               py::ssize_t seed,
                bool use_cs=true)
 {
     py::dict ret;
@@ -91,11 +91,10 @@ py::dict cpp_pycluster(const Matrix &mat, unsigned int k, double beta,
                uint64_t seed=13,
                unsigned lspprounds=0,
                bool use_exponential_skips=false,
-               size_t kmcrounds=1000,
                size_t kmeansmaxiter=1000,
-               Py_ssize_t mbsize=-1,
-               Py_ssize_t ncheckins=-1,
-               Py_ssize_t reseed_count=-1,
+               py::ssize_t mbsize=-1,
+               py::ssize_t ncheckins=-1,
+               py::ssize_t reseed_count=-1,
                bool with_rep=true)
 {
     blz::DV<FT> prior{FT(beta)};
@@ -108,7 +107,7 @@ py::dict cpp_pycluster(const Matrix &mat, unsigned int k, double beta,
         using ComputeT = std::conditional_t<(sizeof(typename Matrix::ElementType) <= 4), float, double>;
         return cmp::msr_with_prior<ComputeT>(measure, y, x, prior, psum, sum(y), sum(x));
     };
-    auto initial_sol = repeatedly_get_initial_centers(mat, rng, k, kmcrounds, ntimes, lspprounds, use_exponential_skips, functor);
+    auto initial_sol = repeatedly_get_initial_centers(mat, rng, k, ntimes, lspprounds, use_exponential_skips, functor);
     auto &[idx, asn, costs] = initial_sol;
     std::vector<blz::CompressedVector<FT, blz::rowVector>> centers(k);
     for(unsigned i = 0; i < k; ++i) {
@@ -125,17 +124,16 @@ py::dict pycluster(const Matrix &smw, int k, double beta,
                int ntimes=3,
                uint64_t seed = 13,
                unsigned lspprounds=0,
-               size_t kmcrounds=1000,
                size_t kmeansmaxiter=1000,
-               Py_ssize_t mbsize=-1,
-               Py_ssize_t ncheckins=-1,
-               Py_ssize_t reseed_count=-1,
+               py::ssize_t mbsize=-1,
+               py::ssize_t ncheckins=-1,
+               py::ssize_t reseed_count=-1,
                bool with_rep=true)
 {
     assert(k >= 1);
     assert(beta > 0.);
     py::dict retdict;
-    smw.perform([&](auto &x) {retdict = cpp_pycluster(x, k, beta, measure, weights, eps, ntimes, seed, lspprounds, kmcrounds, kmeansmaxiter, mbsize, ncheckins, reseed_count, with_rep);});
+    smw.perform([&](auto &x) {retdict = cpp_pycluster(x, k, beta, measure, weights, eps, ntimes, seed, lspprounds, kmeansmaxiter, mbsize, ncheckins, reseed_count, with_rep);});
     return retdict;
 }
 
@@ -147,8 +145,8 @@ py::object __py_cluster_from_centers(const Matrix &smw,
                     uint64_t kmeansmaxiter,
                     //size_t kmcrounds, int ntimes, int lspprounds,
                     uint64_t seed,
-                    Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                    Py_ssize_t reseed_count, bool with_rep, bool use_cs=false)
+                    py::ssize_t mbsize, py::ssize_t ncheckins,
+                    py::ssize_t reseed_count, bool with_rep, bool use_cs=false)
 {
     blz::DV<double> prior{double(beta)};
     const dist::DissimilarityMeasure measure = assure_dm(msr);

--- a/python/pycluster_csr.cpp
+++ b/python/pycluster_csr.cpp
@@ -5,13 +5,11 @@ void init_clustering_csr(py::module &m) {
     m.def("hcluster", [](const PyCSparseMatrix &smw, py::object centers, double beta,
                     py::object msr, py::object weights, double eps,
                     uint64_t kmeansmaxiter,
-                        //size_t kmcrounds, int ntimes, int lspprounds,
                     uint64_t seed,
-                    Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                    Py_ssize_t reseed_count, bool with_rep, bool use_cs) -> py::object
+                    py::ssize_t mbsize, py::ssize_t ncheckins,
+                    py::ssize_t reseed_count, bool with_rep, bool use_cs) -> py::object
     {
         return __py_cluster_from_centers(smw, centers, beta, msr, weights, eps, kmeansmaxiter,
-                //kmcrounds, ntimes, lspprounds,
                 seed,
                 mbsize, ncheckins, reseed_count, with_rep, use_cs);
     },
@@ -23,9 +21,9 @@ void init_clustering_csr(py::module &m) {
     py::arg("eps") = 1e-10,
     py::arg("maxiter") = 100,
     py::arg("seed") = 0,
-    py::arg("mbsize") = Py_ssize_t(-1),
-    py::arg("ncheckins") = Py_ssize_t(-1),
-    py::arg("reseed_count") = Py_ssize_t(5),
+    py::arg("mbsize") = py::ssize_t(-1),
+    py::arg("ncheckins") = py::ssize_t(-1),
+    py::arg("reseed_count") = py::ssize_t(5),
     py::arg("with_rep") = false,
     py::arg("cs") = false
     );

--- a/python/pycluster_dense.cpp
+++ b/python/pycluster_dense.cpp
@@ -8,8 +8,8 @@ py::object __py_cluster_from_centers_dense(py::array_t<FT, py::array::c_style | 
                     uint64_t kmeansmaxiter,
                     //size_t kmcrounds, int ntimes, int lspprounds,
                     uint64_t seed,
-                    Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                    Py_ssize_t reseed_count, bool with_rep, bool use_cs=false)
+                    py::ssize_t mbsize, py::ssize_t ncheckins,
+                    py::ssize_t reseed_count, bool with_rep, bool use_cs=false)
 {
     blz::DV<double> prior{double(beta)};
     const dist::DissimilarityMeasure measure = assure_dm(msr);
@@ -68,8 +68,8 @@ void init_clustering_dense(py::module &m) {
 
     m.def("hcluster", [](py::array dataset, py::object centers, double beta,
                          py::object msr, py::object weights, double eps,
-                         uint64_t kmeansmaxiter, uint64_t seed, Py_ssize_t mbsize, Py_ssize_t ncheckins,
-                         Py_ssize_t reseed_count, bool with_rep, bool use_cs) {
+                         uint64_t kmeansmaxiter, uint64_t seed, py::ssize_t mbsize, py::ssize_t ncheckins,
+                         py::ssize_t reseed_count, bool with_rep, bool use_cs) {
                             constexpr const int pyflags = py::array::c_style | py::array::forcecast;
                             py::object ret = py::none();
                             try {
@@ -104,9 +104,9 @@ void init_clustering_dense(py::module &m) {
     py::arg("eps") = 1e-10,
     py::arg("maxiter") = 100,
     py::arg("seed") = 0,
-    py::arg("mbsize") = Py_ssize_t(-1),
-    py::arg("ncheckins") = Py_ssize_t(-1),
-    py::arg("reseed_count") = Py_ssize_t(5),
+    py::arg("mbsize") = py::ssize_t(-1),
+    py::arg("ncheckins") = py::ssize_t(-1),
+    py::arg("reseed_count") = py::ssize_t(5),
     py::arg("with_rep") = false, py::arg("cs") = false,
     "Clusters a SparseMatrixWrapper object using settings and the centers provided above; set prior to < 0 for it to be 1 / ncolumns(). Performs seeding, followed by EM or minibatch k-means");
 } // init_clustering

--- a/python/pycluster_soft.cpp
+++ b/python/pycluster_soft.cpp
@@ -3,7 +3,7 @@
 void init_clustering_soft(py::module &m) {
     m.def("scluster", [](const SparseMatrixWrapper &smw, py::object centers,
                     py::object measure, double beta, double temp,
-                    uint64_t kmeansmaxiter, Py_ssize_t mbsize, Py_ssize_t mbn,
+                    uint64_t kmeansmaxiter, py::ssize_t mbsize, py::ssize_t mbn,
                     py::object savepref, py::object weights) -> py::object
     {
         void *wptr = nullptr;
@@ -21,8 +21,8 @@ void init_clustering_soft(py::module &m) {
     py::arg("prior") = 0.,
     py::arg("temp") = 1.,
     py::arg("maxiter") = 1000,
-    py::arg("mbsize") = Py_ssize_t(-1),
-    py::arg("mbn") = Py_ssize_t(-1),
+    py::arg("mbsize") = py::ssize_t(-1),
+    py::arg("mbn") = py::ssize_t(-1),
     py::arg("savepref") = "",
     py::arg("weights") = py::none()
     );

--- a/python/pycluster_soft.h
+++ b/python/pycluster_soft.h
@@ -24,8 +24,8 @@ py::dict cpp_scluster(const Matrix &mat, int, double beta,
                AsnT &asn,
                double temp,
                size_t kmeansmaxiter,
-               Py_ssize_t mbsize,
-               Py_ssize_t mbn,
+               py::ssize_t mbsize,
+               py::ssize_t mbn,
                void *weights=static_cast<void *>(nullptr),
                char wdtype='f')
 {
@@ -78,8 +78,8 @@ py::dict py_scluster(const Matrix &smw,
                double beta,
                double temp=1.,
                size_t kmeansmaxiter=1000,
-               Py_ssize_t mbsize=-1,
-               Py_ssize_t mbn=10,
+               py::ssize_t mbsize=-1,
+               py::ssize_t mbn=10,
                std::string savepref="",
                void *weights = (void *)nullptr,
                std::string wfmt="f")
@@ -89,7 +89,7 @@ py::dict py_scluster(const Matrix &smw,
     std::vector<blz::CompressedVector<float, blz::rowVector>> dvecs;
     smw.perform([&](auto &mat) {dvecs = obj2dvec(centers, mat);});
     const int k = dvecs.size();
-    std::vector<Py_ssize_t> shape{Py_ssize_t(smw.rows()), k};
+    std::vector<py::ssize_t> shape{py::ssize_t(smw.rows()), k};
     assert(k >= 1);
     if(!savepref.empty()) {
         std::fprintf(stderr, "Using savepref to mmap cost matrices diretly: %s\n", savepref.data());

--- a/python/pycluster_softcsr.cpp
+++ b/python/pycluster_softcsr.cpp
@@ -3,7 +3,7 @@
 void init_clustering_soft_csr(py::module &m) {
     m.def("scluster", [](const PyCSparseMatrix &smw, py::object centers,
                     py::object measure, double beta, double temp,
-                    uint64_t kmeansmaxiter, Py_ssize_t mbsize, Py_ssize_t mbn,
+                    uint64_t kmeansmaxiter, py::ssize_t mbsize, py::ssize_t mbn,
                     py::object savepref, py::object weights) -> py::object
     {
         void *wptr = nullptr;
@@ -22,8 +22,8 @@ void init_clustering_soft_csr(py::module &m) {
     py::arg("prior") = 0.,
     py::arg("temp") = 1.,
     py::arg("maxiter") = 1000,
-    py::arg("mbsize") = Py_ssize_t(-1),
-    py::arg("mbn") = Py_ssize_t(-1),
+    py::arg("mbsize") = py::ssize_t(-1),
+    py::arg("mbn") = py::ssize_t(-1),
     py::arg("savepref") = "",
     py::arg("weights") = py::none()
     );

--- a/python/pycluster_softdense.cpp
+++ b/python/pycluster_softdense.cpp
@@ -6,8 +6,8 @@ py::dict py_scluster_arr(py::array matrix,
                double prior,
                double temp=1.,
                size_t kmeansmaxiter=1000,
-               Py_ssize_t mbsize=-1,
-               Py_ssize_t mbn=10,
+               py::ssize_t mbsize=-1,
+               py::ssize_t mbn=10,
                std::string savepref="",
                void *weights = (void *)nullptr,
                std::string wfmt="f")
@@ -30,7 +30,7 @@ py::dict py_scluster_arr(py::array matrix,
         nr = fmatinf.shape[0];
     }
     const int k = dvecs.size();
-    std::vector<Py_ssize_t> shape{nr, k};
+    std::vector<py::ssize_t> shape{nr, k};
     assert(k >= 1);
     if(!savepref.empty()) {
         std::fprintf(stderr, "Using savepref to mmap cost matrices diretly: %s\n", savepref.data());
@@ -65,7 +65,7 @@ py::dict py_scluster_arr(py::array matrix,
 void init_clustering_softdense(py::module &m) {
     m.def("scluster", [](py::array mat, py::object centers,
                     py::object measure, double prior, double temp,
-                    uint64_t kmeansmaxiter, Py_ssize_t mbsize, Py_ssize_t mbn,
+                    uint64_t kmeansmaxiter, py::ssize_t mbsize, py::ssize_t mbn,
                     py::object savepref, py::object weights) -> py::object
     {
         if(prior < 0.) prior = 0.;
@@ -84,8 +84,8 @@ void init_clustering_softdense(py::module &m) {
     py::arg("prior") = 0.,
     py::arg("temp") = 1.,
     py::arg("maxiter") = 1000,
-    py::arg("mbsize") = Py_ssize_t(-1),
-    py::arg("mbn") = Py_ssize_t(-1),
+    py::arg("mbsize") = py::ssize_t(-1),
+    py::arg("mbn") = py::ssize_t(-1),
     py::arg("savepref") = "",
     py::arg("weights") = py::none()
     );

--- a/python/pycs.cpp
+++ b/python/pycs.cpp
@@ -23,7 +23,7 @@ void init_coreset(py::module &m) {
                 dp = (double *)winf.ptr;
             else throw std::invalid_argument("Weights can only be double or float");
         }
-        const Py_ssize_t np = costs.shape(0);
+        const py::ssize_t np = costs.shape(0);
         switch(buf1.format[0]) {
             case 'f': if(dp) {
                         cs.make_sampler(np, ncenters, (float *)buf1.ptr, asnp, dp, seed, sens); break;
@@ -46,7 +46,7 @@ void init_coreset(py::module &m) {
         std::copy(cs.probs_.get(), cs.probs_.get() + cs.np_, (float *)ret.request().ptr);
         return ret;
     }, "Create a numpy array of sampling probabilities")
-    .def("sample", [](CSType &cs, Py_ssize_t size, Py_ssize_t seed, bool unique_samples, double eps) {
+    .def("sample", [](CSType &cs, py::ssize_t size, py::ssize_t seed, bool unique_samples, double eps) {
         if(cs.sampler_ == nullptr) throw std::invalid_argument("Can't sample without created sampler. Call make_ampler");
         if(seed == 0) seed = std::rand();
         auto ret = cs.sample(size, seed, eps, unique_samples);

--- a/python/pycsparse.h
+++ b/python/pycsparse.h
@@ -39,7 +39,7 @@ struct PyCSparseMatrix {
     std::string indptr_t_;
     size_t nr_, nc_, nnz_;
     template<typename DataT, typename IndicesT, typename IndPtrT>
-    PyCSparseMatrix(DataT *data, const IndicesT *indices, const IndPtrT *indptr, Py_ssize_t nr, Py_ssize_t nc, Py_ssize_t nnz):
+    PyCSparseMatrix(DataT *data, const IndicesT *indices, const IndPtrT *indptr, py::ssize_t nr, py::ssize_t nc, py::ssize_t nnz):
         datap_((void *)data),
         indicesp_((void *)indices),
         indptrp_((void *)indptr),
@@ -54,9 +54,9 @@ struct PyCSparseMatrix {
     PyCSparseMatrix(PyCSparseMatrix &&) = default;
     PyCSparseMatrix &operator=(const PyCSparseMatrix &) = default;
     PyCSparseMatrix &operator=(PyCSparseMatrix &&) = default;
-    PyCSparseMatrix(py::object obj): PyCSparseMatrix(py::cast<py::array>(obj.attr("data")), py::cast<py::array>(obj.attr("indices")), py::cast<py::array>(obj.attr("indptr")), py::int_(py::cast<py::sequence>(obj.attr("shape"))[0]).cast<Py_ssize_t>(),
-                                                    py::int_(py::cast<py::sequence>(obj.attr("shape"))[1]).cast<Py_ssize_t>(), obj.attr("nnz").cast<Py_ssize_t>()) {}
-    PyCSparseMatrix(py::array data, py::array indices, py::array indptr, Py_ssize_t nr, Py_ssize_t nc, Py_ssize_t nnz): nr_(nr), nc_(nc), nnz_(nnz)
+    PyCSparseMatrix(py::object obj): PyCSparseMatrix(py::cast<py::array>(obj.attr("data")), py::cast<py::array>(obj.attr("indices")), py::cast<py::array>(obj.attr("indptr")), py::int_(py::cast<py::sequence>(obj.attr("shape"))[0]).cast<py::ssize_t>(),
+                                                    py::int_(py::cast<py::sequence>(obj.attr("shape"))[1]).cast<py::ssize_t>(), obj.attr("nnz").cast<py::ssize_t>()) {}
+    PyCSparseMatrix(py::array data, py::array indices, py::array indptr, py::ssize_t nr, py::ssize_t nc, py::ssize_t nnz): nr_(nr), nc_(nc), nnz_(nnz)
     {
         auto datainf = data.request();
         auto indicesinf = indices.request();

--- a/python/pydense.cpp
+++ b/python/pydense.cpp
@@ -31,6 +31,7 @@ py::tuple mat2tup(py::array_t<FT, py::array::c_style | py::array::forcecast> arr
 
 void init_pydense(py::module &m) {
 
+#if 0
      m.def("kmeanspp", [](py::array_t<float, py::array::c_style | py::array::forcecast> arr, const SumOpts &so, py::object weights) {
         auto arri = arr.request();
         if(arri.ndim != 2) throw std::invalid_argument("Wrong number of dimensions");
@@ -55,12 +56,14 @@ void init_pydense(py::module &m) {
        py::arg("opts"),
        py::arg("weights") = py::none()
     );
+#endif
      m.def("kmeanspp", [](py::array_t<float, py::array::c_style | py::array::forcecast> arr, int k, py::object measure, py::object prior, py::object seed, py::object nkmc, py::object ntimes,
                           py::object lspp, py::object weights, py::object expskips, py::object local_trials) {
         auto dm = assure_dm(measure);
         auto arri = arr.request();
         if(arri.ndim != 2) throw std::invalid_argument("Wrong number of dimensions");
         blz::CustomMatrix<float, unaligned, unpadded, rowMajor> cm((float *)arri.ptr, arri.shape[0], arri.shape[1], arri.strides[0] / sizeof(float));
+        std::fprintf(stderr, "Doing kmeans++ over matrix at %p with floats\n", arri.ptr);
         return py_kmeanspp_noso_dense(cm, py::int_(int(dm)), py::int_(k), prior.cast<double>(), seed.cast<py::ssize_t>(), nkmc.cast<py::ssize_t>(), std::max(ntimes.cast<int>() - 1, 0),
                              lspp.cast<py::ssize_t>(), expskips.cast<bool>(), local_trials.cast<py::ssize_t>(), weights);
     },
@@ -78,11 +81,12 @@ void init_pydense(py::module &m) {
        py::arg("n_local_trials") = 1
     );
      m.def("kmeanspp", [](py::array_t<double, py::array::c_style> arr, int k, py::object measure, py::object prior, py::object seed, py::object nkmc, py::object ntimes,
-                          py::object lspp, py::object weights, py::object expskips, py::object local_trials) {
+                          py::object lspp, py::object weights, py::object expskips, py::object local_trials) -> py::object {
         auto dm = assure_dm(measure);
         auto arri = arr.request();
         if(arri.ndim != 2) throw std::invalid_argument("Wrong number of dimensions");
         blz::CustomMatrix<double, unaligned, unpadded, rowMajor> cm((double *)arri.ptr, arri.shape[0], arri.shape[1], arri.strides[0] / sizeof(double));
+        std::fprintf(stderr, "Doing kmeans++ over matrix at %p with doubles\n", arri.ptr);
         return py_kmeanspp_noso_dense(cm, py::int_(int(dm)), py::int_(k), prior.cast<double>(), seed.cast<py::ssize_t>(), nkmc.cast<py::ssize_t>(), std::max(ntimes.cast<int>() - 1, 0),
                              lspp.cast<py::ssize_t>(), expskips.cast<bool>(), local_trials.cast<py::ssize_t>(), weights);
     },

--- a/python/pydense.cpp
+++ b/python/pydense.cpp
@@ -37,7 +37,7 @@ void init_pydense(py::module &m) {
         auto arri = arr.request();
         if(arri.ndim != 2) throw std::invalid_argument("Wrong number of dimensions");
         blz::CustomMatrix<float, unaligned, unpadded, rowMajor> cm((float *)arri.ptr, arri.shape[0], arri.shape[1], arri.strides[0] / sizeof(float));
-        std::fprintf(stderr, "Doing kmeans++ over matrix at %p with floats\n", arri.ptr);
+        DBG_ONLY(std::fprintf(stderr, "Doing kmeans++ over matriy at %p with floats\n", arri.ptr);)
         return py_kmeanspp_noso_dense(cm, py::int_(int(dm)), py::int_(k), prior.cast<double>(), seed.cast<py::ssize_t>(), std::max(ntimes.cast<int>() - 1, 0),
                              lspp.cast<py::ssize_t>(), expskips.cast<bool>(), local_trials.cast<py::ssize_t>(), weights);
     },

--- a/python/pyhelpers.h
+++ b/python/pyhelpers.h
@@ -45,19 +45,19 @@ void set_centers(VecT *vec, const py::buffer_info &bi) {
     auto &v = *vec;
     switch(bi.format.front()) {
         case 'L': case 'l':
-            for(Py_ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint64_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
+            for(py::ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint64_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
         break;
         case 'I': case 'i':
-            for(Py_ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint32_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
+            for(py::ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint32_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
         break;
         case 'B': case 'b':
-            for(Py_ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint8_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
+            for(py::ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint8_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
         break;
-        case 'H': case 'h': for(Py_ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint16_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
+        case 'H': case 'h': for(py::ssize_t i = 0; i < bi.shape[0]; ++i) v.emplace_back(trans(blz::make_cv((uint16_t *)bi.ptr + i * bi.shape[1], bi.shape[1])));
         break;
-        case 'f': for(Py_ssize_t i = 0; i < bi.shape[0]; ++i) {v.emplace_back(trans(blz::make_cv((float *)bi.ptr + i * bi.shape[1], bi.shape[1])));}
+        case 'f': for(py::ssize_t i = 0; i < bi.shape[0]; ++i) {v.emplace_back(trans(blz::make_cv((float *)bi.ptr + i * bi.shape[1], bi.shape[1])));}
         break;
-        case 'd': for(Py_ssize_t i = 0; i < bi.shape[0]; ++i) {v.emplace_back(trans(blz::make_cv((double *)bi.ptr + i * bi.shape[1], bi.shape[1])));}
+        case 'd': for(py::ssize_t i = 0; i < bi.shape[0]; ++i) {v.emplace_back(trans(blz::make_cv((double *)bi.ptr + i * bi.shape[1], bi.shape[1])));}
         break;
         default: throw std::invalid_argument(std::string("Invalid format string: ") + bi.format);
     }
@@ -147,7 +147,7 @@ inline std::vector<blz::CompressedVector<float, blz::rowVector>> obj2dvec(py::ob
             try {
             const size_t nc = mat.columns();
             for(auto item: py::cast<py::sequence>(x)) {
-                Py_ssize_t rownum = py::cast<py::int_>(item).cast<Py_ssize_t>();
+                py::ssize_t rownum = py::cast<py::int_>(item).cast<py::ssize_t>();
                 auto &v = dvecs.emplace_back();
                 v.resize(nc);
                 auto r = row(mat, rownum);
@@ -201,7 +201,7 @@ std::vector<blz::DynamicVector<FT, blz::rowVector>> obj2dvec(
             auto dbi = dataset.request();
             const size_t nc = dbi.shape[1];
             for(auto item: py::cast<py::sequence>(x)) {
-                const py::ssize_t rownum = py::cast<py::int_>(item).cast<Py_ssize_t>();
+                const py::ssize_t rownum = py::cast<py::int_>(item).cast<py::ssize_t>();
                 auto &v = dvecs.emplace_back();
                 v.resize(nc);
                 switch(standardize_dtype(dbi.format)[0]) {
@@ -217,7 +217,7 @@ std::vector<blz::DynamicVector<FT, blz::rowVector>> obj2dvec(
     return dvecs;
 }
 
-inline std::string size2dtype(Py_ssize_t n) {
+inline std::string size2dtype(py::ssize_t n) {
     if(n > 0xFFFFFFFFu) return "L";
     if(n > 0xFFFFu) return "I";
     if(n > 0xFFu) return "H";

--- a/python/smw.h
+++ b/python/smw.h
@@ -304,8 +304,8 @@ inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, d
             gamma_beta = 1. / smw.columns();
             std::fprintf(stderr, "Warning: unset beta prior defaults to 1 / # columns (%g)\n", gamma_beta);
         }
+        //std::fprintf(stderr, "Starting %s\n", __PRETTY_FUNCTION__);
         if(seed == 0) seed = std::mt19937_64(std::rand())();
-        if(nkmc > 1) std::fprintf(stderr, "Warning: nkmc been removed.\n");
         const void *wptr = nullptr;
         int kind = -1;
         const auto mmsr = assure_dm(msr);
@@ -336,10 +336,14 @@ inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, d
         } else if(ki <= 63356) {
             retasn = py::array_t<uint16_t>(nr);
             retasnbits = 16;
-        } else {
+        } else if(ki <= 0xFFFFFFFFu) {
             retasn = py::array_t<uint32_t>(nr);
             retasnbits = 32;
+        } else {
+            retasn = py::array_t<uint64_t>(nr);
+            retasnbits = 64;
         }
+        //std::fprintf(stderr, "retasnbits is %u\n", retasnbits);
         auto retai = py::cast<py::array>(retasn).request();
         auto rptr = (uint32_t *)ret.request().ptr;
         py::array_t<float> costs(smw.rows());
@@ -348,8 +352,23 @@ inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, d
         using FT = std::conditional_t<sizeof(TmpT) <= 4, float, double>;
         using minicore::util::sum;
         using blz::sum;
+        //std::fprintf(stderr, "Got pointers and info\n");
         blaze::DynamicVector<double> rsums(smw.rows());
-        rsums = sum<blaze::rowwise>(smw);
+        //std::fprintf(stderr, "Computing sum over the matrix\n");
+#if 0
+        if constexpr(blaze::IsCustom_v<Mat>) {
+            OMP_PFOR
+            for(size_t i = 0; i < smw.rows(); ++i) {
+                auto r(row(smw, i));
+                
+            }
+        } else {
+            rsums = sum<blaze::rowwise>(smw);
+        }
+#else
+            rsums = sum<blaze::rowwise>(smw);
+#endif
+        // std::fprintf(stderr, "Computed sum over the matrix\n");
         auto cmp = [&smw,measure=mmsr,rsums=rsums.data(),psum,&prior](size_t xi, size_t yi) {
             // Note that this has been transposed
             auto rx = row(smw, xi, blz::unchecked), ry = row(smw, yi, blz::unchecked);
@@ -361,45 +380,35 @@ inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, d
             case 'd': case -1: break;
             default: throw std::runtime_error("Unsupported dtype for weights");
         }
+        //std::fprintf(stderr, "Weights: %p\n", tmpw.get());
         auto sol = kmeanspp(cmp, rng, smw.rows(), ki, (double *)wptr, lspp, use_exponential_skips, true, n_local_trials);
+        //std::fprintf(stderr, "Performed first kmeans++\n");
         auto solc = sum(std::get<2>(sol));
         for(auto nt = 0u;nt < ntimes; ++nt) {
+            //std::fprintf(stderr, "Performing %dth kmeans++\n", nt + 1);
             auto sol2 = kmeanspp(cmp, rng, smw.rows(), ki, (double *)wptr, lspp, use_exponential_skips, true, n_local_trials);
             auto sol2c = sum(std::get<2>(sol2));
             if(sol2c < solc) {
                 std::swap(sol2, sol); std::swap(sol2c, solc);
-                std::fprintf(stderr, "Replaced old cost of %0.20g with %0.20g\n", sol2c, solc);
+                //std::fprintf(stderr, "Replaced old cost of %0.20g with %0.20g\n", sol2c, solc);
             }
         }
         auto &lidx = std::get<0>(sol);
         auto &lasn = std::get<1>(sol);
         auto &lcosts = std::get<2>(sol);
+        const size_t e = lasn.size();
+        //std::fprintf(stderr, "Copying out\n");
         switch(retasnbits) {
-            case 8: {
-                auto raptr = (uint8_t *)retai.ptr;
-                OMP_PFOR
-                for(size_t i = 0; i < lasn.size(); ++i)
-                    raptr[i] = lasn[i];
-            } break;
-            case 16: {
-                auto raptr = (uint16_t *)retai.ptr;
-                OMP_PFOR
-                for(size_t i = 0; i < lasn.size(); ++i)
-                    raptr[i] = lasn[i];
-            } break;
-            case 32: {
-                auto raptr = (uint32_t *)retai.ptr;
-                OMP_PFOR
-                for(size_t i = 0; i < lasn.size(); ++i)
-                    raptr[i] = lasn[i];
-            } break;
+#define __C(N, T) case N: {std::copy(lasn.begin(), lasn.end(), (T *)retai.ptr);} break
+            __C(8, uint8_t);
+            __C(16, uint16_t);
+            __C(32, uint32_t);
+            __C(64, uint64_t);
+#undef __C
             default: __builtin_unreachable();
         }
-        //std::fprintf(stderr, "Computed initial centers\n");
-        for(size_t i = 0; i < lcosts.size(); ++i)
-            costp[i] = lcosts[i];
-        for(size_t i = 0; i < lidx.size(); ++i)
-            rptr[i] = lidx[i];
+        std::copy(lcosts.begin(), lcosts.end(), costp);
+        std::copy(lidx.begin(), lidx.end(), rptr);
         return py::make_tuple(ret, retasn, costs);
     }
 

--- a/python/smw.h
+++ b/python/smw.h
@@ -396,7 +396,6 @@ inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, d
         auto &lidx = std::get<0>(sol);
         auto &lasn = std::get<1>(sol);
         auto &lcosts = std::get<2>(sol);
-        const size_t e = lasn.size();
         //std::fprintf(stderr, "Copying out\n");
         switch(retasnbits) {
 #define __C(N, T) case N: {std::copy(lasn.begin(), lasn.end(), (T *)retai.ptr);} break

--- a/python/smw.h
+++ b/python/smw.h
@@ -177,7 +177,7 @@ public:
 };
 
 template<typename Mat>
-inline py::object py_kmeanspp_noso(Mat &smw, py::object msr, py::int_ k, double gamma_beta, uint64_t seed, unsigned nkmc, unsigned ntimes,
+inline py::object py_kmeanspp_noso(Mat &smw, py::object msr, py::int_ k, double gamma_beta, uint64_t seed, unsigned ntimes,
                           py::ssize_t lspp, bool use_exponential_skips, py::ssize_t n_local_trials,
                           py::object weights)
     {
@@ -185,7 +185,6 @@ inline py::object py_kmeanspp_noso(Mat &smw, py::object msr, py::int_ k, double 
             gamma_beta = 1. / smw.columns();
             std::fprintf(stderr, "Warning: unset beta prior defaults to 1 / # columns (%g)\n", gamma_beta);
         }
-        if(nkmc > 1) std::fprintf(stderr, "Warning: nkmc been removed.\n");
         if(seed == 0) seed = std::mt19937_64(std::rand())();
         const void *wptr = nullptr;
         int kind = -1;
@@ -205,7 +204,7 @@ inline py::object py_kmeanspp_noso(Mat &smw, py::object msr, py::int_ k, double 
                 }
             }
         }
-        auto ki = k.cast<Py_ssize_t>();
+        auto ki = k.cast<py::ssize_t>();
         wy::WyRand<uint64_t> rng(seed);
         const auto psum = gamma_beta * smw.columns();
         const blz::StaticVector<double, 1> prior({gamma_beta});
@@ -291,13 +290,13 @@ inline py::object py_kmeanspp_noso(Mat &smw, py::object msr, py::int_ k, double 
 
 template<typename Mat>
 inline py::tuple py_kmeanspp_so(const Mat &smw, const SumOpts &sm, py::object weights) {
-    return py_kmeanspp_noso(smw, py::int_((int)sm.dis), sm.k, sm.gamma, sm.seed, sm.kmc2_rounds, std::max(sm.extra_sample_tries - 1, 0u),
+    return py_kmeanspp_noso(smw, py::int_((int)sm.dis), sm.k, sm.gamma, sm.seed, std::max(sm.extra_sample_tries - 1, 0u),
                        sm.lspp, sm.use_exponential_skips, sm.n_local_trials, weights);
 }
 
 template<typename Mat>
-inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, double gamma_beta, uint64_t seed, unsigned nkmc, unsigned ntimes,
-                          Py_ssize_t lspp, bool use_exponential_skips, py::ssize_t n_local_trials,
+inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, double gamma_beta, uint64_t seed, unsigned ntimes,
+                          py::ssize_t lspp, bool use_exponential_skips, py::ssize_t n_local_trials,
                           py::object weights)
     {
         if(gamma_beta < 0.) {
@@ -323,7 +322,7 @@ inline py::object py_kmeanspp_noso_dense(Mat &smw, py::object msr, py::int_ k, d
                 break;
             }
         }
-        auto ki = k.cast<Py_ssize_t>();
+        auto ki = k.cast<py::ssize_t>();
         wy::WyRand<uint64_t> rng(seed);
         const auto psum = gamma_beta * smw.columns();
         const blz::StaticVector<double, 1> prior({gamma_beta});

--- a/python/utility.cpp
+++ b/python/utility.cpp
@@ -6,7 +6,7 @@ dist::DissimilarityMeasure obj2m(py::str o) {
     throw std::invalid_argument("invalid key");
 }
 dist::DissimilarityMeasure obj2m(py::int_ o) {
-    auto i = py::cast<Py_ssize_t>(o);
+    auto i = py::cast<py::ssize_t>(o);
     if(!dist::is_valid_measure((dist::DissimilarityMeasure)i)) {
         std::fprintf(stderr, "Warning: measure %td is not considered valid. Downstream work may break.\n", std::ptrdiff_t(i));
     }
@@ -21,7 +21,7 @@ coresets::SensitivityMethod obj2sm(py::str o) {
 }
 
 coresets::SensitivityMethod obj2sm(py::int_ o) {
-    auto i = py::cast<Py_ssize_t>(o);
+    auto i = py::cast<py::ssize_t>(o);
     return static_cast<coresets::SensitivityMethod>(i);
 }
 


### PR DESCRIPTION
1. Support use_float arguments for cmp and pcmp, which changes the resolution of the distances computed.
2. Wrap important functions in pure python with useful __doc__ strings.
3. In addition to `cmp`, which performs pairwise distances between sparse/dense matrices, `pcmp` performs pairwise similarities across one matrix. This can cut time/space in half.

This pull request also seems to prevent a segfault in kmeanspp for dense matrices.