### PR TITLE
Hierarchical clustering + Sparse L2 median fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ STATIC_LIBS=libsleef.a
 #ls libsimdsampling/libsimdsampling.a 2>/dev/null || (cd libsimdsampling && $(MAKE) libsimdsampling.a INCLUDE_PATHS="../sleef/build/include" LINK_PATHS="../sleef/build/lib" && cd ..)
 
 %: src/tests/%.o $(HEADERS) $(STATIC_LIBS) libsleef.dyn.gen
-	$(CXX) $(CXXFLAGS) $< -o $@ -pthread -DNDEBUG $(OMP_STR) $(STATIC_LIBS) libkl/libkl.a libsimdsampling/libsimdsampling.a
+	$(CXX) $(CXXFLAGS) $< -o $@ -pthread -UNDEBUG $(OMP_STR) $(STATIC_LIBS) libkl/libkl.a libsimdsampling/libsimdsampling.a
 
 src/tests/%.o: src/tests/%.cpp $(HEADERS) $(STATIC_LIBS) libsleef.dyn.gen
-	$(CXX) $(CXXFLAGS) -c $< -o $@ -pthread -DNDEBUG $(OMP_STR) $(STATIC_LIBS)
+	$(CXX) $(CXXFLAGS) -c $< -o $@ -pthread -UNDEBUG $(OMP_STR) $(STATIC_LIBS)
 
 %.dbgo: %.cpp $(HEADERS) $(STATIC_LIBS)  libsleef.dyn.gen
 	$(CXX) $(CXXFLAGS) -c $< -o $@ -pthread  $(OMP_STR) $(STATIC_LIBS)  -O1

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LIBPATHS+=sleef/build/lib
 LIBPATHS+=sleef/dynbuild/lib
 endif
 
-LINKS+= -lsleef #-lkl -lsimdsampling
+LINKS+= # -lsleef #-lkl -lsimdsampling
 
 ifdef TBBDIR
 INCLUDE_PATHS+= $(TBBDIR)/include

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -111,6 +111,7 @@ void set_center(CtrT &ctr, const util::CSparseMatrix<DataT, IndicesT, IndPtrT> &
 
 template<typename CtrT, typename DataT, typename IndicesT, typename IndPtrT, typename IT, typename WeightT>
 void set_center_l2(CtrT &center, const util::CSparseMatrix<DataT, IndicesT, IndPtrT> &mat, IT *asp, size_t nasn, WeightT *weights, double eps=0.) {
+    std::fprintf(stderr, "Setting center via util::geomedian\n");
     util::geomedian(mat, center, asp, nasn, weights, eps);
 }
 
@@ -123,12 +124,12 @@ decltype(auto) elements(const std::vector<VT, Alloc> &w, IT *asp, size_t nasn) {
 template<typename CtrT, typename MT, typename IT, typename WeightT>
 void set_center_l2(CtrT &center, const blaze::Matrix<MT, blaze::rowMajor> &mat, IT *asp, size_t nasn, WeightT *weights, double eps=0.) {
     auto rowsel = rows(mat, asp, nasn);
-    VERBOSE_ONLY(std::cerr << "Calculating geometric median for " << nasn << " rows and storing in " << center << '\n';)
+    std::cerr << "Calculating geometric median for " << nasn << " rows and storing in " << center << '\n';
     if(weights)
         blz::geomedian(rowsel, center, elements(*weights, asp, nasn), eps);
     else
         blz::geomedian(rowsel, center, eps);
-    VERBOSE_ONLY(std::cerr << "Calculated geometric median; new values: " << ctrs[i] << '\n';)
+    std::cerr << "Calculated geometric median; new values: " << center << '\n';
 }
 
 
@@ -590,6 +591,7 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
     wy::WyRand<asn_t, 4> rng(costs.size());
     blaze::SmallArray<asn_t, 16> sa;
     for(unsigned i = 0; i < k; ++i) if(assigned[i].empty()) blz::push_back(sa, i);
+    std::fprintf(stderr, "Setting centroids; %zu empty\n", sa.size());
     while(!sa.empty()) {
         // Compute partial sum
         std::vector<uint32_t> idxleft;
@@ -632,11 +634,13 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
         }
         for(const auto &subasn: assigned) if(subasn.empty()) sa.pushBack(&subasn - assigned.data());
     }
+    std::fprintf(stderr, "reseeded empty\n");
     for(unsigned i = 0; i < k; ++i) {
         const auto nasn = assigned[i].size();
         const auto asp = assigned[i].data();
         MINOCORE_VALIDATE(nasn != 0);
         if(nasn == 1) {
+            std::fprintf(stderr, "Setting centroid for cluster of size 1 to the only representative.\n");
             set_center(ctrs[i], row(mat, *asp));
         } else {
             set_center_l2(ctrs[i], mat, asp, nasn, weights, eps);

--- a/include/minicore/clustering/centroid.h
+++ b/include/minicore/clustering/centroid.h
@@ -111,7 +111,6 @@ void set_center(CtrT &ctr, const util::CSparseMatrix<DataT, IndicesT, IndPtrT> &
 
 template<typename CtrT, typename DataT, typename IndicesT, typename IndPtrT, typename IT, typename WeightT>
 void set_center_l2(CtrT &center, const util::CSparseMatrix<DataT, IndicesT, IndPtrT> &mat, IT *asp, size_t nasn, WeightT *weights, double eps=0.) {
-    std::fprintf(stderr, "Setting center via util::geomedian\n");
     util::geomedian(mat, center, asp, nasn, weights, eps);
 }
 
@@ -591,7 +590,6 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
     wy::WyRand<asn_t, 4> rng(costs.size());
     blaze::SmallArray<asn_t, 16> sa;
     for(unsigned i = 0; i < k; ++i) if(assigned[i].empty()) blz::push_back(sa, i);
-    std::fprintf(stderr, "Setting centroids; %zu empty\n", sa.size());
     while(!sa.empty()) {
         // Compute partial sum
         std::vector<uint32_t> idxleft;
@@ -634,13 +632,11 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
         }
         for(const auto &subasn: assigned) if(subasn.empty()) sa.pushBack(&subasn - assigned.data());
     }
-    std::fprintf(stderr, "reseeded empty\n");
     for(unsigned i = 0; i < k; ++i) {
         const auto nasn = assigned[i].size();
         const auto asp = assigned[i].data();
         MINOCORE_VALIDATE(nasn != 0);
         if(nasn == 1) {
-            std::fprintf(stderr, "Setting centroid for cluster of size 1 to the only representative.\n");
             set_center(ctrs[i], row(mat, *asp));
         } else {
             set_center_l2(ctrs[i], mat, asp, nasn, weights, eps);

--- a/include/minicore/optim/kmedian.h
+++ b/include/minicore/optim/kmedian.h
@@ -154,7 +154,7 @@ void l1_unweighted_median(const blz::Matrix<MT, SO> &data, blz::Vector<VT, TF> &
         std::fprintf(stderr, "val %g at %zu\n", val, i);
 #endif
         __assign(rr, i,  val);
-        assert(rr[i] == val || !std::fprintf(stderr, "rr[i] %g vs %g\n", double(rr[i]), val));
+        assert(rr[i] == val || !std::fprintf(stderr, "rr[i] %g vs %g\n", double(rr[i]), double(val)));
     }
 }
 

--- a/include/minicore/util/blaze_adaptor.h
+++ b/include/minicore/util/blaze_adaptor.h
@@ -684,8 +684,7 @@ auto &geomedian(const Matrix<MT, SO> &mat, Vector<VT, !SO> &dv, const WeightType
         } else {
             costs = weights / costs;
         }
-        double denom = 1. / sum(costs);
-        *dv = trans(costs * denom) * *mat;
+        *dv = trans(costs * (1. / sum(costs))) * *mat;
         prevcost = current_cost;
     }
     return *dv;

--- a/include/minicore/util/csc.h
+++ b/include/minicore/util/csc.h
@@ -1167,9 +1167,9 @@ void geomedian(const CSparseMatrix<VT, IT, IPtrT> &mat, RetT &center, IT2 *ptr =
         if(weights) costs = *weights / costs;
         else costs = 1. / costs;
         costs /= sum(costs);
-        newcenter = 0.;
     
         if(nt <= 1) {
+            newcenter = 0.;
             for(index_t i = 0; i < npoints; ++i) {
                 const index_t ind = ptr ? index_t(ptr[i]): i;
                 //std::fprintf(stderr, "Index %zu is %zu\n", i, ind);
@@ -1201,15 +1201,18 @@ void geomedian(const CSparseMatrix<VT, IT, IPtrT> &mat, RetT &center, IT2 *ptr =
                 newcenter = trans(blaze::sum<blaze::columnwise>(localsums));
             }
         }
+        center = newcenter;
+#if 0
         if constexpr (blaze::IsSparseVector_v<std::decay_t<RetT>>)  {
-            //const size_t nz = nonZeros(newcenter);
             //DBG_ONLY(std::fprintf(stderr, "[%s] Reserved capacity %zu. Ret size: %zu\n", __PRETTY_FUNCTION__, center.capacity(), center.size());)
-            center = blz::SV<double, blaze::TransposeFlag_v<RetT>>(newcenter);
+            center = newcenter;
+            //center = blz::SV<double, blaze::TransposeFlag_v<RetT>>(newcenter);
             //assign(center, newcenter);
             //DBG_ONLY(std::fprintf(stderr, "[%s] After assign capacity %zu. Ret size: %zu\n", __PRETTY_FUNCTION__, center.capacity(), center.size());)
         } else {
             assign(center, newcenter);
         }
+#endif
     }
 }
 

--- a/include/minicore/util/csc.h
+++ b/include/minicore/util/csc.h
@@ -1138,6 +1138,8 @@ void geomedian(const CSparseMatrix<VT, IT, IPtrT> &mat, RetT &center, IT2 *ptr =
     using index_t = std::common_type_t<IT2, size_t>;
     blz::DV<double> costs(npoints);
     int nt = 1;
+    blaze::DynamicMatrix<double> localsums;
+    blz::DV<double, blaze::TransposeFlag_v<RetT>> newcenter(mat.columns(), 0);
 #ifdef _OPENMP
     #pragma omp parallel
     {
@@ -1150,46 +1152,61 @@ void geomedian(const CSparseMatrix<VT, IT, IPtrT> &mat, RetT &center, IT2 *ptr =
                            MINVAL);
         double current_cost = sum(costs);
         double dist = std::abs(prevcost - current_cost);
-        if(dist <= eps) {std::fprintf(stderr, "Dist %g < eps %g\n", dist, eps); break;}
+        if(dist <= eps) {std::fprintf(stderr, "[%s] Dist %0.20g < eps %0.20g at iternum %zu (prev %0.20g, current %0.20g), breaking\n", __PRETTY_FUNCTION__, dist, eps, iternum, prevcost, current_cost); break;}
+        if(current_cost > prevcost) {
+            std::fprintf(stderr, "[%s] Current cost %0.20g > prevcost %0.20g at iteration %zu. Breaking\n", __PRETTY_FUNCTION__, current_cost, prevcost, iternum);
+            break;
+        }
         if(std::isnan(dist)) throw std::range_error("distance is nan");
         if(++iternum == 100000) {
             std::fprintf(stderr, "Failed to terminate: %g\n", dist);
             break;
         }
-        std::fprintf(stderr, "[%s] Working on iteration number %zu. prevcost %g, current %g\n", __PRETTY_FUNCTION__, iternum, prevcost, current_cost);
+        VERBOSE_ONLY(std::fprintf(stderr, "[%s] Working on iteration number %zu. prevcost %0.20g, current %0.20g\n", __PRETTY_FUNCTION__, iternum, prevcost, current_cost);)
         prevcost = current_cost;
         if(weights) costs = *weights / costs;
         else costs = 1. / costs;
         costs /= sum(costs);
-        blz::DV<double, blaze::TransposeFlag_v<RetT>> newcenter(mat.columns(), 0);
+        newcenter = 0.;
     
-        std::fprintf(stderr, "Computing sum\n");
-        if(1) {
+        if(nt <= 1) {
             for(index_t i = 0; i < npoints; ++i) {
-                for(const auto &pair: row(mat, ptr ? index_t(ptr[i]): i)) {
+                const index_t ind = ptr ? index_t(ptr[i]): i;
+                //std::fprintf(stderr, "Index %zu is %zu\n", i, ind);
+                for(const auto &pair: row(mat, ind)) {
+                    //std::fprintf(stderr, "Row %zu has pair with values %zu/%g\n", ind, pair.index(), double(pair.value()));
                     assert(pair.index() < newcenter.size());
-                    assert((ptr ? index_t(ptr[i]): i) < npoints);
-                    newcenter[pair.index()] += pair.value() * costs[i];
+                    assert(ind < npoints);
+                    assert(ind < costs.size());
+                    //std::fprintf(stderr, "Updating index %zu with value %g and weight %g. Newcenter size: %zu\n", pair.index(), pair.value(), costs[ind], newcenter.size());
+                    newcenter[pair.index()] = std::fma(pair.value(), costs[ind], newcenter[pair.index()]);
                 }
             }
         } else {
-#if 0
-            std::vector<blz::SV<double, blaze::TransposeFlag_v<RetT>>> localsums(nt);
-            OMP_PFOR
-            for(int i = 0; i < nt; i++) localsums[i] = 0.;
-            if(ptr) {
-                OMP_PFOR
-            } else {
+            if(localsums.rows() != uint32_t(nt) || mat.columns() != localsums.columns()) {
+                localsums.resize(nt, mat.columns());
             }
-#endif
+            localsums = 0.;
+            OMP_PFOR
+            for(index_t i = 0; i < npoints; ++i) {
+                const index_t ind = ptr ? index_t(ptr[i]): i;
+                auto myrow = row(localsums, OMP_ELSE(omp_get_thread_num(), 0));
+                for(const auto &pair: row(mat, ind)) {
+                    myrow[pair.index()] = std::fma(pair.value(), costs[ind], myrow[pair.index()]);
+                }
+            }
+            if constexpr(blaze::TransposeFlag_v<RetT> == blaze::TransposeFlag_v<decltype(row(localsums, 0))>) {
+                newcenter = blaze::sum<blaze::columnwise>(localsums);
+            } else {
+                newcenter = trans(blaze::sum<blaze::columnwise>(localsums));
+            }
         }
         if constexpr (blaze::IsSparseVector_v<std::decay_t<RetT>>)  {
             //const size_t nz = nonZeros(newcenter);
-            std::fprintf(stderr, "[%s] Computed sum\n", __PRETTY_FUNCTION__);
-            center.reserve(newcenter.size());
-            std::fprintf(stderr, "[%s] Reserved capacity %zu. Ret size: %zu\n", __PRETTY_FUNCTION__, center.capacity(), center.size());
-            assign(center, newcenter);
-            std::fprintf(stderr, "[%s] After assign capacity %zu. Ret size: %zu\n", __PRETTY_FUNCTION__, center.capacity(), center.size());
+            //DBG_ONLY(std::fprintf(stderr, "[%s] Reserved capacity %zu. Ret size: %zu\n", __PRETTY_FUNCTION__, center.capacity(), center.size());)
+            center = blz::SV<double, blaze::TransposeFlag_v<RetT>>(newcenter);
+            //assign(center, newcenter);
+            //DBG_ONLY(std::fprintf(stderr, "[%s] After assign capacity %zu. Ret size: %zu\n", __PRETTY_FUNCTION__, center.capacity(), center.size());)
         } else {
             assign(center, newcenter);
         }

--- a/include/minicore/util/div.h
+++ b/include/minicore/util/div.h
@@ -134,14 +134,18 @@ template<> struct Schismatic<uint32_t> {
         return div_t<uint32_t> {tmpd, v - d_ * tmpd};
     }
 };
+#if 0
 template<> struct Schismatic<int32_t>: Schismatic<uint32_t> {
-    template<typename...Args>Schismatic<int32_t>(Args &&...args):
-        Schismatic<uint32_t>(std::forward<Args>(args)...){}
+    using BT = Schismatic<uint32_t>;
+    template<typename... Args>
+        Schismatic<int32_t>(Args &&...args):
+            BT(std::forward<Args>(args)...){}
 };
 template<> struct Schismatic<int64_t>: Schismatic<uint64_t> {
     template<typename...Args>Schismatic<int64_t>(Args &&...args):
         Schismatic<uint64_t>(std::forward<Args>(args)...){}
 };
+#endif
 
 } // namespace schism
 

--- a/minicore/__init__.py
+++ b/minicore/__init__.py
@@ -2,6 +2,7 @@ from pyminicore import kmeanspp as pykmpp
 from pyminicore import SumOpts, CSparseMatrix, CoresetSampler
 from pyminicore import pcmp, cmp
 from pyminicore import SparseMatrixWrapper as smw
+from pyminicore import get_counthist
 import pyminicore
 from .util import constants
 from .util.constants import CSR as csr_tuple, KMCRSV

--- a/minicore/__init__.py
+++ b/minicore/__init__.py
@@ -2,7 +2,7 @@ from pyminicore import kmeanspp as pykmpp
 from pyminicore import SumOpts, CSparseMatrix, CoresetSampler
 from pyminicore import pcmp, cmp
 from pyminicore import SparseMatrixWrapper as smw
-from pyminicore import get_counthist
+from pyminicore import get_counthist, set_num_threads, get_num_threads
 import pyminicore
 from .util import constants
 from .util.constants import CSR as csr_tuple, KMCRSV

--- a/minicore/__init__.py
+++ b/minicore/__init__.py
@@ -10,6 +10,7 @@ import numpy as np
 from .util.compute_variance import variance
 from .util import hvg
 import scipy.sparse as sp
+from minicore.recursive_cluster import hiercluster_kmeanspp
 
 
 def cluster_from_centers(*args, **kwargs):

--- a/minicore/recursive_cluster.py
+++ b/minicore/recursive_cluster.py
@@ -1,0 +1,50 @@
+import minicore as mc
+import itertools
+import sys
+import numpy as np
+from collections import Counter
+
+def hiercluster_kmeanspp(dataset, radix=5, msr="JSD", n_local_trials=2, lspp=0, maxiter=3, optimize_centers=True, prior=1e-5, hierdepth=0, mbsize=-1):
+    kmo = mc.kmeanspp(dataset, k=radix, msr=msr, n_local_trials=n_local_trials, lspp=lspp, prior=prior)
+    centers, assignments, costs = kmo
+    if optimize_centers:
+        out = mc.hcluster(dataset, centers=centers, maxiter=maxiter, mbsize=mbsize)
+        centers = out['centers']
+        assignments = out['asn']
+        costs = out['costs']
+    print(centers)
+    base = {"dataset": dataset, "radix": radix, "msr": msr, "centerids": centers,"asn": assignments, "costs:": costs, "hierdepth": hierdepth}
+    if isinstance(centers, np.ndarray) and centers.ndim == 1:
+        base["centers"] = dataset[centers].copy()
+    else:
+        base["centers"] = centers
+    children = {}
+    # print(base)
+    idlabelmap = mc.get_counthist(assignments)
+    idc = {k: len(v) for k, v in idlabelmap.items()}
+    # print("labelmap: ", idc)
+    for k, v in idlabelmap.items():
+        if len(v) > radix:
+            subdataset = dataset[v].copy()
+            children[k] = hiercluster_kmeanspp(subdataset, radix=radix, msr=msr, n_local_trials=n_local_trials, lspp=lspp, prior=prior, optimize_centers=optimize_centers, maxiter=maxiter, hierdepth=hierdepth + 1, mbsize=mbsize)
+    base['children'] = children
+    return base
+
+
+if __name__ == "__main__":
+    dataset = np.random.rand(102400).reshape(-1, 16)
+    print(dataset.shape)
+    radix = 25
+    out = hiercluster_kmeanspp(dataset, radix=radix, msr="SQRL2")
+    print("Base clustering has %d labels" % radix)
+    subsets = list(out['children'].items())
+    for k, v in subsets:
+        print(f"Subset for subset {k} has {v['dataset'].shape}-shaped dataset")
+    keys = [k for k, v in subsets]
+    vals = [v for k, v in subsets]
+    subsubsets = list(itertools.chain.from_iterable(list(x['children'].items()) for x in vals))
+    subkeys = [k for k, v in subsubsets]
+    subvals = [v for k, v in subsubsets]
+    print(subsubsets[0])
+    for subk, v in zip(subkeys, subvals):
+        print(f"Subset for subsub label {subk} has {v['dataset'].shape}-shaped dataset")

--- a/python/pycounthist.cpp
+++ b/python/pycounthist.cpp
@@ -107,7 +107,6 @@ T get_argmax(const py::dict input) {
 py::object get_counthist1d(const py::buffer_info &bi) {
     if(bi.ndim != 1) throw std::runtime_error("Expected 1-d Numpy Array");
     py::object ret = py::none();
-    std::fprintf(stderr, "counthist for dtype %s\n", bi.format.data());
     switch(standardize_dtype(bi.format).front()) {
         case 'f': ret = get_counthist((float *)bi.ptr, bi.size); break;
         case 'd': ret = get_counthist((double *)bi.ptr, bi.size); break;

--- a/python/pycounthist.cpp
+++ b/python/pycounthist.cpp
@@ -1,0 +1,213 @@
+#include "pyfgc.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/numpy.h"
+#include "aesctr/wy.h"
+#include "minicore/minicore.h"
+#include <mutex>
+
+
+template<typename T>
+shared::flat_hash_map<T, std::pair<std::vector<size_t>, std::unique_ptr<std::mutex>>> get_map(const T *items, const py::ssize_t nelem) {
+    shared::flat_hash_map<T, std::pair<std::vector<size_t>, std::unique_ptr<std::mutex>>> map;
+    OMP_PFOR
+    for(py::ssize_t i = 0; i < nelem; ++i) {
+        const T v = items[i];
+        auto it = map.find(v);
+        if(it == map.end()) {
+            std::pair<std::vector<size_t>, std::unique_ptr<std::mutex>> value({}, new std::mutex);
+            it = map.emplace(v, std::move(value)).first;
+        }
+        auto &rhs = it->second;
+        std::lock_guard<std::mutex> lock(*rhs.second);
+        rhs.first.push_back(i);
+    }
+    return map;
+}
+
+#if 0
+T get_argmaxcount(const char dt, const void *items, const py::ssize_t nelem) {
+    shared::flat_hash_map<T, std::pair<std::vector<size_t>, std::unique_ptr<std::mutex>>> map = get_map(items, nelem);
+    for(py::ssize_t i = 0; i < nelem; ++i) {
+        const T v = items[i];
+        auto it = map.find(v);
+        if(it == map.end()) {
+            std::pair<std::vector<size_t>, std::unique_ptr<std::mutex>> value({}, new std::mutex);
+            it = map.emplace(v, std::move(value)).first;
+        }
+        auto &rhs = it->second;
+        std::lock_guard<std::mutex> lock(*rhs.second);
+        rhs.first.push_back(i);
+    }
+}
+#endif
+
+
+
+template<typename T>
+py::dict get_counthist(const T *items, const py::ssize_t nelem) {
+    const auto map = get_map(items, nelem);
+    const std::string dt = size2dtype(nelem);
+    const auto retdt = py::dtype(dt);
+    py::dict ret;
+    py::buffer_info bi;
+    for(const auto &pair: map) {
+        const py::ssize_t nmatches = pair.second.first.size();
+        py::array cpy(retdt, std::vector<py::ssize_t>{nmatches});
+        bi = cpy.request();
+        const size_t *startp = pair.second.first.data(), *endp = startp + nmatches;
+        switch(dt.front()) {
+            case 'L': std::copy(startp, endp, (uint64_t *)bi.ptr); break;
+            case 'I': std::copy(startp, endp, (uint32_t *)bi.ptr); break;
+            case 'H': std::copy(startp, endp, (uint16_t *)bi.ptr); break;
+            case 'B': std::copy(startp, endp, (uint8_t *)bi.ptr); break;
+            default: __builtin_unreachable();
+        }
+        ret[py::cast(pair.first)] = cpy;
+    }
+    return ret;
+}
+
+template<typename T>
+T get_argmax(const shared::flat_hash_map<T, std::pair<std::vector<size_t>, std::unique_ptr<std::mutex>>> &input) {
+    size_t maxc = 0;
+    T asn = std::numeric_limits<T>::max();
+    for(const auto &item: input) {
+        if(const size_t ct = item.second.first.size(); ct > maxc) {
+            maxc = ct;
+            asn = item.first;
+        }
+    }
+    return asn;
+}
+
+template<typename T>
+T get_argmax(const py::dict input) {
+    size_t maxc = 0;
+    T asn = std::numeric_limits<T>::max();
+    for(const auto item: input) {
+        if(item.second.cast<T>() > maxc) {
+            maxc = item.second;
+            asn = item.first;
+        }
+    }
+    return asn;
+}
+
+py::object get_counthist1d(const py::buffer_info &bi) {
+    if(bi.ndim != 1) throw std::runtime_error("Expected 1-d Numpy Array");
+    py::object ret = py::none();
+    switch(standardize_dtype(bi.format).front()) {
+        case 'f': ret = get_counthist((float *)bi.ptr, bi.size); break;
+        case 'd': ret = get_counthist((double *)bi.ptr, bi.size); break;
+        case 'B': case 'b': ret = get_counthist((uint8_t *)bi.ptr, bi.size); break;
+        case 'H': case 'h': ret = get_counthist((uint16_t *)bi.ptr, bi.size); break;
+        case 'I': case 'i': ret = get_counthist((int32_t *)bi.ptr, bi.size); break;
+        case 'L': case 'l': ret = get_counthist((uint64_t *)bi.ptr, bi.size); break;
+        default: throw std::invalid_argument(std::string("Unexpected dtype: ") + bi.format);
+    }
+    return ret;
+}
+
+py::object get_counthist_wrapper(py::array rhs) {
+    py::list ret;
+    py::buffer_info bi = rhs.request();
+    if(bi.ndim == 1)
+        return get_counthist1d(bi);
+    if(bi.ndim != 2) throw std::runtime_error("Expected 2-d Numpy Array");
+    const py::ssize_t nc = bi.shape[1], nr = bi.shape[0];
+    for(py::ssize_t i = 0; i < nr; ++i) {
+        py::object next = py::none();
+        const uint8_t *startp = (uint8_t *)bi.ptr + bi.strides[0];
+        switch(standardize_dtype(bi.format).front()) {
+            case 'f': next = get_counthist((float *)startp, nc); break;
+            case 'd': next = get_counthist((double *)startp, nc); break;
+            case 'B': case 'b': next = get_counthist((uint8_t *)startp, nc); break;
+            case 'H': case 'h': next = get_counthist((uint16_t *)startp, nc); break;
+            case 'I': case 'i': next = get_counthist((uint32_t *)startp, nc); break;
+            case 'L': case 'l': next = get_counthist((uint64_t *)startp, nc); break;
+            default: throw std::invalid_argument(std::string("Unexpected dtype: ") + bi.format);
+        }
+        ret.append(next);
+    }
+    return ret;
+}
+
+
+template<typename T>
+py::array_t<T> get_argmaxcount(const py::buffer_info &bi) {
+    if(bi.ndim != 2) throw std::invalid_argument("Expected 2-d array for get_argcountmax");
+    py::array_t<T> ret({bi.shape[0]});
+    py::buffer_info rbi = ret.request();
+    const size_t rowlen = bi.strides[0] / sizeof(T);
+    const py::ssize_t nc = bi.shape[1], nr = bi.shape[0];
+    OMP_PFOR
+    for(py::ssize_t i = 0; i < nr; ++i) {
+        const T *srcptr = (const T *)bi.ptr + (i * rowlen);
+        ((T *)rbi.ptr)[i] = get_argmax(get_map(srcptr, nc));
+    }
+    return ret;
+}
+
+py::object get_argmaxcount_base(const py::buffer_info &bi) {
+    switch(standardize_dtype(bi.format).front()) {
+        case 'f': return get_argmaxcount<float>(bi);
+        case 'd': return get_argmaxcount<double>(bi);
+        case 'b': return get_argmaxcount<int8_t>(bi);
+        case 'B': return get_argmaxcount<uint8_t>(bi);
+        case 'h': return get_argmaxcount<int16_t>(bi);
+        case 'H': return get_argmaxcount<uint16_t>(bi);
+        case 'i': return get_argmaxcount<int32_t>(bi);
+        case 'I': return get_argmaxcount<uint32_t>(bi);
+        case 'l': return get_argmaxcount<int64_t>(bi);
+        case 'L': return get_argmaxcount<uint64_t>(bi);
+        default: ;
+    }
+    return py::none();
+}
+
+#if 0
+py::object countmax(py::array rhs) {
+    py::buffer_info bi = rhs.request();
+    if(bi.ndim == 1) {
+        return py::int_(get_argmax<size_t>(get_counthist1d(bi)));
+    }
+    const auto dtc = standardize_dtype(bi.format).front();
+    py::array ret = py::array(py::dtype(bi.format), std::vector<py::ssize_t>{bi.shape[0]});
+    py::buffer_info retbi = ret.request();
+    const size_t offset = bi.strides[0] / bi.itemsize;
+    OMP_PFOR
+    for(size_t i = 0; i < bi.shape[0]; ++i) {
+        const uint8_t *ptr = (const uint8_t *)bi.ptr + offset * i;
+        auto map = get_argmax(dtc, ptr, bi.shape[1]);
+        ret[i] = get_argmax<
+    }
+}
+
+py::array get_asn(py::array rhs) {
+    py::object list ret;
+    py::list ret;
+    py::buffer_info bi = rhs.request();
+    const auto dtc = standardize_dtype(bi.format).front();
+    if(bi.ndim == 1)
+        return get_counthist(bi);
+    py::array ret(dtc
+    if(bi.ndim != 2) throw std::runtime_error("Expected 2-d Numpy Array");
+    for(py::ssize_t i = 0; i < bi.shape[0]; ++i) {
+        py::object next = py::none();
+        switch(dtc) {
+            case 'B': case 'b': next = get_counthist((uint8_t *)bi.ptr, bi.size); break;
+            case 'H': case 'h': next = get_counthist((uint16_t *)bi.ptr, bi.size); break;
+            case 'I': case 'i': next = get_counthist((int32_t *)bi.ptr, bi.size); break;
+            case 'L': case 'l': next = get_counthist((uint64_t *)bi.ptr, bi.size); break;
+            default: throw std::invalid_argument(std::string("Unexpected dtype: ") + bi.format);
+        }
+        ret.append(next);
+    }
+    return ret;
+}
+#endif
+
+void init_counthist(py::module &m) {
+    m.def("get_counthist", get_counthist_wrapper);
+    m.def("get_argmaxcount", get_argmaxcount_base);
+}

--- a/python/pyfgc.cpp
+++ b/python/pyfgc.cpp
@@ -15,5 +15,6 @@ PYBIND11_MODULE(pyminicore, m) {
     init_pydense(m);
     init_arrcmp(m);
     init_clustering_softdense(m);
+    init_counthist(m);
     m.doc() = "Python bindings for FGC, which allows for calling coreset/clustering code from numpy and converting results back to numpy arrays";
 }

--- a/python/pyfgc.h
+++ b/python/pyfgc.h
@@ -23,6 +23,7 @@ void init_clustering_soft(py::module &m);
 void init_pydense(py::module &m);
 void init_arrcmp(py::module &m);
 void init_clustering_softdense(py::module &m);
+void init_counthist(py::module &m);
 //void init_hvg(py::module &m);
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ SLEEFLIB="libsleef.a"
 sleefdir = environ.get("SLEEF_DIR", "sleef/build")
 
 def main():
-    if 0:
-        #if "CONDA_PREFIX" in environ:
+    if "CONDA_PREFIX" in environ:
         from dynsetup import dyn_main
         return dyn_main()
 

--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,13 @@ def main():
 
     #EXTRAS = environ.get("EXTRA", "")
 
-    extra_compile_args = ['-march=native', '-DNDEBUG',
+    extra_compile_args = ['-march=native', '-UNDEBUG',
                           '-Wno-char-subscripts', '-Wno-unused-function', '-Wno-ignored-qualifiers',
                           '-Wno-strict-aliasing', '-Wno-ignored-attributes', '-fno-wrapv',
                           '-Wall', '-Wextra', '-Wformat',
                           '-lz', '-fopenmp', "-DEXTERNAL_BOOST_IOSTREAMS=1",
                           "-DBLAZE_USE_SLEEF=1", "-pipe",
-                          '-Wno-deprecated-declarations', '-O3']
+                          '-Wno-deprecated-declarations', '-O0']
 
     if 'BOOST_DIR' in environ:
         extra_compile_args.append("-I%s" % environ['BOOST_DIR'])

--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,13 @@ def main():
 
     #EXTRAS = environ.get("EXTRA", "")
 
-    extra_compile_args = ['-march=native', '-UNDEBUG',
+    extra_compile_args = ['-march=native', '-DNDEBUG',
                           '-Wno-char-subscripts', '-Wno-unused-function', '-Wno-ignored-qualifiers',
                           '-Wno-strict-aliasing', '-Wno-ignored-attributes', '-fno-wrapv',
                           '-Wall', '-Wextra', '-Wformat',
                           '-lz', '-fopenmp', "-DEXTERNAL_BOOST_IOSTREAMS=1",
                           "-DBLAZE_USE_SLEEF=1", "-pipe",
-                          '-Wno-deprecated-declarations', '-O0']
+                          '-Wno-deprecated-declarations', '-O3']
 
     if 'BOOST_DIR' in environ:
         extra_compile_args.append("-I%s" % environ['BOOST_DIR'])

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def main():
     import distutils.ccompiler
     distutils.ccompiler.CCompiler.compile=parallelCCompile
 
-    LIBOBJS = [SLEEFLIB, "libkl.a", "libsimdsampling/libsimdsampling.a", "libgomp.a"]
+    LIBOBJS = [SLEEFLIB, "libkl.a", "libsimdsampling/libsimdsampling.a"]
     # On some systems, it seems that gomp needs to be statically linked ["libgomp.a"]
 
 
@@ -74,7 +74,7 @@ def main():
                           '-Wno-char-subscripts', '-Wno-unused-function', '-Wno-ignored-qualifiers',
                           '-Wno-strict-aliasing', '-Wno-ignored-attributes', '-fno-wrapv',
                           '-Wall', '-Wextra', '-Wformat',
-                          '-lz', '-fopenmp', "-DEXTERNAL_BOOST_IOSTREAMS=1",
+                          '-lz', '-fopenmp', "-DEXTERNAL_BOOST_IOSTREAMS=1", "-lgomp",
                           "-DBLAZE_USE_SLEEF=1", "-pipe",
                           '-Wno-deprecated-declarations', '-O3']
 
@@ -137,7 +137,7 @@ def main():
         raise RuntimeError('Unsupported compiler -- at least C++11 support '
                            'is needed!')
 
-    extra_link_opts = ["-fopenmp", "-lz", "-DEXTERNAL_BOOST_IOSTREAMS=1"] + LIBOBJS
+    extra_link_opts = ["-fopenmp", "-lz", "-DEXTERNAL_BOOST_IOSTREAMS=1", "-lgomp"] + LIBOBJS
 
 
     class BuildExt(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ SLEEFLIB="libsleef.a"
 sleefdir = environ.get("SLEEF_DIR", "sleef/build")
 
 def main():
-    if "CONDA_PREFIX" in environ:
+    if 0:
+        #if "CONDA_PREFIX" in environ:
         from dynsetup import dyn_main
         return dyn_main()
 
@@ -22,8 +23,8 @@ def main():
     if not path.isfile("libsimdsampling/libsimdsampling.a"):
         print("Making libss.a")
         check_call(f"make libsimdsampling/libsimdsampling.a", shell=True)
-    #if not path.isfile("libgomp.a"):
-    #    check_call(f"ln -s `{environ.get('CXX', 'g++')} --print-file-name=libgomp.a`", shell=True, executable="/bin/bash")
+    if not path.isfile("libgomp.a"):
+        check_call(f"ln -s `{environ.get('CXX', 'g++')} --print-file-name=libgomp.a`", shell=True, executable="/bin/bash")
 
     # from https://stackoverflow.com/questions/11013851/speeding-up-build-process-with-distutils
     # parallelizes extension compilation
@@ -49,7 +50,7 @@ def main():
     import distutils.ccompiler
     distutils.ccompiler.CCompiler.compile=parallelCCompile
 
-    LIBOBJS = [SLEEFLIB, "libkl.a", "libsimdsampling/libsimdsampling.a"]
+    LIBOBJS = [SLEEFLIB, "libkl.a", "libsimdsampling/libsimdsampling.a", "libgomp.a"]
     # On some systems, it seems that gomp needs to be statically linked ["libgomp.a"]
 
 
@@ -73,7 +74,7 @@ def main():
                           '-Wno-char-subscripts', '-Wno-unused-function', '-Wno-ignored-qualifiers',
                           '-Wno-strict-aliasing', '-Wno-ignored-attributes', '-fno-wrapv',
                           '-Wall', '-Wextra', '-Wformat',
-                          '-lz', '-fopenmp', "-lgomp", "-DEXTERNAL_BOOST_IOSTREAMS=1",
+                          '-lz', '-fopenmp', "-DEXTERNAL_BOOST_IOSTREAMS=1",
                           "-DBLAZE_USE_SLEEF=1", "-pipe",
                           '-Wno-deprecated-declarations', '-O3']
 
@@ -136,7 +137,7 @@ def main():
         raise RuntimeError('Unsupported compiler -- at least C++11 support '
                            'is needed!')
 
-    extra_link_opts = ["-fopenmp", "-lgomp", "-lz", "-DEXTERNAL_BOOST_IOSTREAMS=1"] + LIBOBJS
+    extra_link_opts = ["-fopenmp", "-lz", "-DEXTERNAL_BOOST_IOSTREAMS=1"] + LIBOBJS
 
 
     class BuildExt(build_ext):


### PR DESCRIPTION
This introduces a fix for the sparse L2 median calculation. This is already fully supported for blaze dense and sparse matrices, but not for CSR matrices. Apparently, blaze::assign(newcenter, othervalue) doesn't always work properly with sparse vectors, but newcenter = blaze::DynamicVector(othervalue) does.

Also uses parallel summation + reduction for this problem, so it's fully parallelized.

Finally, adds a method for hierarchical clustering, which can be used for summarization and indexing. This only supports hard clustering currently; perhaps there's a suitable soft clustering relaxation to use.